### PR TITLE
Numpy tests types and dtypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ __pycache__/*
 autogen/__pycache__
 torch_np/__pycache__/*
 torch_np/tests/__pycache__/*
+torch_np/tests/numpy_tests/core/__pycache__/*
 .coverage
 

--- a/torch_np/tests/numpy_tests/core/test_dtype.py
+++ b/torch_np/tests/numpy_tests/core/test_dtype.py
@@ -1,0 +1,1827 @@
+import sys
+import operator
+import pytest
+import ctypes
+import gc
+import types
+from typing import Any
+
+import numpy as np
+from numpy.core._rational_tests import rational
+from numpy.core._multiarray_tests import create_custom_field_dtype
+from numpy.testing import (
+    assert_, assert_equal, assert_array_equal, assert_raises, HAS_REFCOUNT,
+    IS_PYSTON, _OLD_PROMOTION)
+from numpy.compat import pickle
+from itertools import permutations
+import random
+
+import hypothesis
+from hypothesis.extra import numpy as hynp
+
+
+
+def assert_dtype_equal(a, b):
+    assert_equal(a, b)
+    assert_equal(hash(a), hash(b),
+                 "two equivalent types do not hash to the same value !")
+
+def assert_dtype_not_equal(a, b):
+    assert_(a != b)
+    assert_(hash(a) != hash(b),
+            "two different types hash to the same value !")
+
+class TestBuiltin:
+    @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
+                                   np.compat.unicode])
+    def test_run(self, t):
+        """Only test hash runs at all."""
+        dt = np.dtype(t)
+        hash(dt)
+
+    @pytest.mark.parametrize('t', [int, float])
+    def test_dtype(self, t):
+        # Make sure equivalent byte order char hash the same (e.g. < and = on
+        # little endian)
+        dt = np.dtype(t)
+        dt2 = dt.newbyteorder("<")
+        dt3 = dt.newbyteorder(">")
+        if dt == dt2:
+            assert_(dt.byteorder != dt2.byteorder, "bogus test")
+            assert_dtype_equal(dt, dt2)
+        else:
+            assert_(dt.byteorder != dt3.byteorder, "bogus test")
+            assert_dtype_equal(dt, dt3)
+
+    def test_equivalent_dtype_hashing(self):
+        # Make sure equivalent dtypes with different type num hash equal
+        uintp = np.dtype(np.uintp)
+        if uintp.itemsize == 4:
+            left = uintp
+            right = np.dtype(np.uint32)
+        else:
+            left = uintp
+            right = np.dtype(np.ulonglong)
+        assert_(left == right)
+        assert_(hash(left) == hash(right))
+
+    def test_invalid_types(self):
+        # Make sure invalid type strings raise an error
+
+        assert_raises(TypeError, np.dtype, 'O3')
+        assert_raises(TypeError, np.dtype, 'O5')
+        assert_raises(TypeError, np.dtype, 'O7')
+        assert_raises(TypeError, np.dtype, 'b3')
+        assert_raises(TypeError, np.dtype, 'h4')
+        assert_raises(TypeError, np.dtype, 'I5')
+        assert_raises(TypeError, np.dtype, 'e3')
+        assert_raises(TypeError, np.dtype, 'f5')
+
+        if np.dtype('g').itemsize == 8 or np.dtype('g').itemsize == 16:
+            assert_raises(TypeError, np.dtype, 'g12')
+        elif np.dtype('g').itemsize == 12:
+            assert_raises(TypeError, np.dtype, 'g16')
+
+        if np.dtype('l').itemsize == 8:
+            assert_raises(TypeError, np.dtype, 'l4')
+            assert_raises(TypeError, np.dtype, 'L4')
+        else:
+            assert_raises(TypeError, np.dtype, 'l8')
+            assert_raises(TypeError, np.dtype, 'L8')
+
+        if np.dtype('q').itemsize == 8:
+            assert_raises(TypeError, np.dtype, 'q4')
+            assert_raises(TypeError, np.dtype, 'Q4')
+        else:
+            assert_raises(TypeError, np.dtype, 'q8')
+            assert_raises(TypeError, np.dtype, 'Q8')
+
+    def test_richcompare_invalid_dtype_equality(self):
+        # Make sure objects that cannot be converted to valid
+        # dtypes results in False/True when compared to valid dtypes.
+        # Here 7 cannot be converted to dtype. No exceptions should be raised
+
+        assert not np.dtype(np.int32) == 7, "dtype richcompare failed for =="
+        assert np.dtype(np.int32) != 7, "dtype richcompare failed for !="
+
+    @pytest.mark.parametrize(
+        'operation',
+        [operator.le, operator.lt, operator.ge, operator.gt])
+    def test_richcompare_invalid_dtype_comparison(self, operation):
+        # Make sure TypeError is raised for comparison operators
+        # for invalid dtypes. Here 7 is an invalid dtype.
+
+        with pytest.raises(TypeError):
+            operation(np.dtype(np.int32), 7)
+
+    @pytest.mark.parametrize("dtype",
+             ['Bool', 'Bytes0', 'Complex32', 'Complex64',
+              'Datetime64', 'Float16', 'Float32', 'Float64',
+              'Int8', 'Int16', 'Int32', 'Int64',
+              'Object0', 'Str0', 'Timedelta64',
+              'UInt8', 'UInt16', 'Uint32', 'UInt32',
+              'Uint64', 'UInt64', 'Void0',
+              "Float128", "Complex128"])
+    def test_numeric_style_types_are_invalid(self, dtype):
+        with assert_raises(TypeError):
+            np.dtype(dtype)
+
+    def test_remaining_dtypes_with_bad_bytesize(self):
+        # The np.<name> aliases were deprecated, these probably should be too 
+        assert np.dtype("int0") is np.dtype("intp")
+        assert np.dtype("uint0") is np.dtype("uintp")
+        assert np.dtype("bool8") is np.dtype("bool")
+        assert np.dtype("bytes0") is np.dtype("bytes")
+        assert np.dtype("str0") is np.dtype("str")
+        assert np.dtype("object0") is np.dtype("object")
+
+    @pytest.mark.parametrize(
+        'value',
+        ['m8', 'M8', 'datetime64', 'timedelta64',
+         'i4, (2,3)f8, f4', 'a3, 3u8, (3,4)a10',
+         '>f', '<f', '=f', '|f',
+        ])
+    def test_dtype_bytes_str_equivalence(self, value):
+        bytes_value = value.encode('ascii')
+        from_bytes = np.dtype(bytes_value)
+        from_str = np.dtype(value)
+        assert_dtype_equal(from_bytes, from_str)
+
+    def test_dtype_from_bytes(self):
+        # Empty bytes object
+        assert_raises(TypeError, np.dtype, b'')
+        # Byte order indicator, but no type
+        assert_raises(TypeError, np.dtype, b'|')
+
+        # Single character with ordinal < NPY_NTYPES returns
+        # type by index into _builtin_descrs
+        assert_dtype_equal(np.dtype(bytes([0])), np.dtype('bool'))
+        assert_dtype_equal(np.dtype(bytes([17])), np.dtype(object))
+
+        # Single character where value is a valid type code
+        assert_dtype_equal(np.dtype(b'f'), np.dtype('float32'))
+
+        # Bytes with non-ascii values raise errors
+        assert_raises(TypeError, np.dtype, b'\xff')
+        assert_raises(TypeError, np.dtype, b's\xff')
+
+    def test_bad_param(self):
+        # Can't give a size that's too small
+        assert_raises(ValueError, np.dtype,
+                        {'names':['f0', 'f1'],
+                         'formats':['i4', 'i1'],
+                         'offsets':[0, 4],
+                         'itemsize':4})
+        # If alignment is enabled, the alignment (4) must divide the itemsize
+        assert_raises(ValueError, np.dtype,
+                        {'names':['f0', 'f1'],
+                         'formats':['i4', 'i1'],
+                         'offsets':[0, 4],
+                         'itemsize':9}, align=True)
+        # If alignment is enabled, the individual fields must be aligned
+        assert_raises(ValueError, np.dtype,
+                        {'names':['f0', 'f1'],
+                         'formats':['i1', 'f4'],
+                         'offsets':[0, 2]}, align=True)
+
+    def test_field_order_equality(self):
+        x = np.dtype({'names': ['A', 'B'],
+                      'formats': ['i4', 'f4'],
+                      'offsets': [0, 4]})
+        y = np.dtype({'names': ['B', 'A'],
+                      'formats': ['i4', 'f4'],
+                      'offsets': [4, 0]})
+        assert_equal(x == y, False)
+        # This is an safe cast (not equiv) due to the different names:
+        assert np.can_cast(x, y, casting="safe")
+
+
+class TestRecord:
+    def test_equivalent_record(self):
+        """Test whether equivalent record dtypes hash the same."""
+        a = np.dtype([('yo', int)])
+        b = np.dtype([('yo', int)])
+        assert_dtype_equal(a, b)
+
+    def test_different_names(self):
+        # In theory, they may hash the same (collision) ?
+        a = np.dtype([('yo', int)])
+        b = np.dtype([('ye', int)])
+        assert_dtype_not_equal(a, b)
+
+    def test_different_titles(self):
+        # In theory, they may hash the same (collision) ?
+        a = np.dtype({'names': ['r', 'b'],
+                      'formats': ['u1', 'u1'],
+                      'titles': ['Red pixel', 'Blue pixel']})
+        b = np.dtype({'names': ['r', 'b'],
+                      'formats': ['u1', 'u1'],
+                      'titles': ['RRed pixel', 'Blue pixel']})
+        assert_dtype_not_equal(a, b)
+
+    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    def test_refcount_dictionary_setting(self):
+        names = ["name1"]
+        formats = ["f8"]
+        titles = ["t1"]
+        offsets = [0]
+        d = dict(names=names, formats=formats, titles=titles, offsets=offsets)
+        refcounts = {k: sys.getrefcount(i) for k, i in d.items()}
+        np.dtype(d)
+        refcounts_new = {k: sys.getrefcount(i) for k, i in d.items()}
+        assert refcounts == refcounts_new
+
+    def test_mutate(self):
+        # Mutating a dtype should reset the cached hash value.
+        # NOTE: Mutating should be deprecated, but new API added to replace it.
+        a = np.dtype([('yo', int)])
+        b = np.dtype([('yo', int)])
+        c = np.dtype([('ye', int)])
+        assert_dtype_equal(a, b)
+        assert_dtype_not_equal(a, c)
+        a.names = ['ye']
+        assert_dtype_equal(a, c)
+        assert_dtype_not_equal(a, b)
+        state = b.__reduce__()[2]
+        a.__setstate__(state)
+        assert_dtype_equal(a, b)
+        assert_dtype_not_equal(a, c)
+
+    def test_mutate_error(self):
+        # NOTE: Mutating should be deprecated, but new API added to replace it.
+        a = np.dtype("i,i")
+
+        with pytest.raises(ValueError, match="must replace all names at once"):
+            a.names = ["f0"]
+
+        with pytest.raises(ValueError, match=".*and not string"):
+            a.names = ["f0", b"not a unicode name"]
+
+    def test_not_lists(self):
+        """Test if an appropriate exception is raised when passing bad values to
+        the dtype constructor.
+        """
+        assert_raises(TypeError, np.dtype,
+                      dict(names={'A', 'B'}, formats=['f8', 'i4']))
+        assert_raises(TypeError, np.dtype,
+                      dict(names=['A', 'B'], formats={'f8', 'i4'}))
+
+    def test_aligned_size(self):
+        # Check that structured dtypes get padded to an aligned size
+        dt = np.dtype('i4, i1', align=True)
+        assert_equal(dt.itemsize, 8)
+        dt = np.dtype([('f0', 'i4'), ('f1', 'i1')], align=True)
+        assert_equal(dt.itemsize, 8)
+        dt = np.dtype({'names':['f0', 'f1'],
+                       'formats':['i4', 'u1'],
+                       'offsets':[0, 4]}, align=True)
+        assert_equal(dt.itemsize, 8)
+        dt = np.dtype({'f0': ('i4', 0), 'f1':('u1', 4)}, align=True)
+        assert_equal(dt.itemsize, 8)
+        # Nesting should preserve that alignment
+        dt1 = np.dtype([('f0', 'i4'),
+                       ('f1', [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')]),
+                       ('f2', 'i1')], align=True)
+        assert_equal(dt1.itemsize, 20)
+        dt2 = np.dtype({'names':['f0', 'f1', 'f2'],
+                       'formats':['i4',
+                                  [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')],
+                                  'i1'],
+                       'offsets':[0, 4, 16]}, align=True)
+        assert_equal(dt2.itemsize, 20)
+        dt3 = np.dtype({'f0': ('i4', 0),
+                       'f1': ([('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')], 4),
+                       'f2': ('i1', 16)}, align=True)
+        assert_equal(dt3.itemsize, 20)
+        assert_equal(dt1, dt2)
+        assert_equal(dt2, dt3)
+        # Nesting should preserve packing
+        dt1 = np.dtype([('f0', 'i4'),
+                       ('f1', [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')]),
+                       ('f2', 'i1')], align=False)
+        assert_equal(dt1.itemsize, 11)
+        dt2 = np.dtype({'names':['f0', 'f1', 'f2'],
+                       'formats':['i4',
+                                  [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')],
+                                  'i1'],
+                       'offsets':[0, 4, 10]}, align=False)
+        assert_equal(dt2.itemsize, 11)
+        dt3 = np.dtype({'f0': ('i4', 0),
+                       'f1': ([('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')], 4),
+                       'f2': ('i1', 10)}, align=False)
+        assert_equal(dt3.itemsize, 11)
+        assert_equal(dt1, dt2)
+        assert_equal(dt2, dt3)
+        # Array of subtype should preserve alignment
+        dt1 = np.dtype([('a', '|i1'),
+                        ('b', [('f0', '<i2'),
+                        ('f1', '<f4')], 2)], align=True)
+        assert_equal(dt1.descr, [('a', '|i1'), ('', '|V3'),
+                                 ('b', [('f0', '<i2'), ('', '|V2'),
+                                 ('f1', '<f4')], (2,))])
+
+    def test_union_struct(self):
+        # Should be able to create union dtypes
+        dt = np.dtype({'names':['f0', 'f1', 'f2'], 'formats':['<u4', '<u2', '<u2'],
+                        'offsets':[0, 0, 2]}, align=True)
+        assert_equal(dt.itemsize, 4)
+        a = np.array([3], dtype='<u4').view(dt)
+        a['f1'] = 10
+        a['f2'] = 36
+        assert_equal(a['f0'], 10 + 36*256*256)
+        # Should be able to specify fields out of order
+        dt = np.dtype({'names':['f0', 'f1', 'f2'], 'formats':['<u4', '<u2', '<u2'],
+                        'offsets':[4, 0, 2]}, align=True)
+        assert_equal(dt.itemsize, 8)
+        # field name should not matter: assignment is by position
+        dt2 = np.dtype({'names':['f2', 'f0', 'f1'],
+                        'formats':['<u4', '<u2', '<u2'],
+                        'offsets':[4, 0, 2]}, align=True)
+        vals = [(0, 1, 2), (3, 2**15-1, 4)]
+        vals2 = [(0, 1, 2), (3, 2**15-1, 4)]
+        a = np.array(vals, dt)
+        b = np.array(vals2, dt2)
+        assert_equal(a.astype(dt2), b)
+        assert_equal(b.astype(dt), a)
+        assert_equal(a.view(dt2), b)
+        assert_equal(b.view(dt), a)
+        # Should not be able to overlap objects with other types
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0', 'f1'],
+                 'formats':['O', 'i1'],
+                 'offsets':[0, 2]})
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0', 'f1'],
+                 'formats':['i4', 'O'],
+                 'offsets':[0, 3]})
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0', 'f1'],
+                 'formats':[[('a', 'O')], 'i1'],
+                 'offsets':[0, 2]})
+        assert_raises(TypeError, np.dtype,
+                {'names':['f0', 'f1'],
+                 'formats':['i4', [('a', 'O')]],
+                 'offsets':[0, 3]})
+        # Out of order should still be ok, however
+        dt = np.dtype({'names':['f0', 'f1'],
+                       'formats':['i1', 'O'],
+                       'offsets':[np.dtype('intp').itemsize, 0]})
+
+    @pytest.mark.parametrize(["obj", "dtype", "expected"],
+        [([], ("(2)f4,"), np.empty((0, 2), dtype="f4")),
+         (3, "(3)f4,", [3, 3, 3]),
+         (np.float64(2), "(2)f4,", [2, 2]),
+         ([((0, 1), (1, 2)), ((2,),)], '(2,2)f4', None),
+         (["1", "2"], "(2)i,", None)])
+    def test_subarray_list(self, obj, dtype, expected):
+        dtype = np.dtype(dtype)
+        res = np.array(obj, dtype=dtype)
+
+        if expected is None:
+            # iterate the 1-d list to fill the array
+            expected = np.empty(len(obj), dtype=dtype)
+            for i in range(len(expected)):
+                expected[i] = obj[i]
+
+        assert_array_equal(res, expected)
+
+    def test_comma_datetime(self):
+        dt = np.dtype('M8[D],datetime64[Y],i8')
+        assert_equal(dt, np.dtype([('f0', 'M8[D]'),
+                                   ('f1', 'datetime64[Y]'),
+                                   ('f2', 'i8')]))
+
+    def test_from_dictproxy(self):
+        # Tests for PR #5920
+        dt = np.dtype({'names': ['a', 'b'], 'formats': ['i4', 'f4']})
+        assert_dtype_equal(dt, np.dtype(dt.fields))
+        dt2 = np.dtype((np.void, dt.fields))
+        assert_equal(dt2.fields, dt.fields)
+
+    def test_from_dict_with_zero_width_field(self):
+        # Regression test for #6430 / #2196
+        dt = np.dtype([('val1', np.float32, (0,)), ('val2', int)])
+        dt2 = np.dtype({'names': ['val1', 'val2'],
+                        'formats': [(np.float32, (0,)), int]})
+
+        assert_dtype_equal(dt, dt2)
+        assert_equal(dt.fields['val1'][0].itemsize, 0)
+        assert_equal(dt.itemsize, dt.fields['val2'][0].itemsize)
+
+    def test_bool_commastring(self):
+        d = np.dtype('?,?,?')  # raises?
+        assert_equal(len(d.names), 3)
+        for n in d.names:
+            assert_equal(d.fields[n][0], np.dtype('?'))
+
+    def test_nonint_offsets(self):
+        # gh-8059
+        def make_dtype(off):
+            return np.dtype({'names': ['A'], 'formats': ['i4'],
+                             'offsets': [off]})
+
+        assert_raises(TypeError, make_dtype, 'ASD')
+        assert_raises(OverflowError, make_dtype, 2**70)
+        assert_raises(TypeError, make_dtype, 2.3)
+        assert_raises(ValueError, make_dtype, -10)
+
+        # no errors here:
+        dt = make_dtype(np.uint32(0))
+        np.zeros(1, dtype=dt)[0].item()
+
+    def test_fields_by_index(self):
+        dt = np.dtype([('a', np.int8), ('b', np.float32, 3)])
+        assert_dtype_equal(dt[0], np.dtype(np.int8))
+        assert_dtype_equal(dt[1], np.dtype((np.float32, 3)))
+        assert_dtype_equal(dt[-1], dt[1])
+        assert_dtype_equal(dt[-2], dt[0])
+        assert_raises(IndexError, lambda: dt[-3])
+
+        assert_raises(TypeError, operator.getitem, dt, 3.0)
+
+        assert_equal(dt[1], dt[np.int8(1)])
+
+    @pytest.mark.parametrize('align_flag',[False, True])
+    def test_multifield_index(self, align_flag):
+        # indexing with a list produces subfields
+        # the align flag should be preserved
+        dt = np.dtype([
+            (('title', 'col1'), '<U20'), ('A', '<f8'), ('B', '<f8')
+        ], align=align_flag)
+
+        dt_sub = dt[['B', 'col1']]
+        assert_equal(
+            dt_sub,
+            np.dtype({
+                'names': ['B', 'col1'],
+                'formats': ['<f8', '<U20'],
+                'offsets': [88, 0],
+                'titles': [None, 'title'],
+                'itemsize': 96
+            })
+        )
+        assert_equal(dt_sub.isalignedstruct, align_flag)
+
+        dt_sub = dt[['B']]
+        assert_equal(
+            dt_sub,
+            np.dtype({
+                'names': ['B'],
+                'formats': ['<f8'],
+                'offsets': [88],
+                'itemsize': 96
+            })
+        )
+        assert_equal(dt_sub.isalignedstruct, align_flag)
+
+        dt_sub = dt[[]]
+        assert_equal(
+            dt_sub,
+            np.dtype({
+                'names': [],
+                'formats': [],
+                'offsets': [],
+                'itemsize': 96
+            })
+        )
+        assert_equal(dt_sub.isalignedstruct, align_flag)
+
+        assert_raises(TypeError, operator.getitem, dt, ())
+        assert_raises(TypeError, operator.getitem, dt, [1, 2, 3])
+        assert_raises(TypeError, operator.getitem, dt, ['col1', 2])
+        assert_raises(KeyError, operator.getitem, dt, ['fake'])
+        assert_raises(KeyError, operator.getitem, dt, ['title'])
+        assert_raises(ValueError, operator.getitem, dt, ['col1', 'col1'])
+
+    def test_partial_dict(self):
+        # 'names' is missing
+        assert_raises(ValueError, np.dtype,
+                {'formats': ['i4', 'i4'], 'f0': ('i4', 0), 'f1':('i4', 4)})
+
+    def test_fieldless_views(self):
+        a = np.zeros(2, dtype={'names':[], 'formats':[], 'offsets':[],
+                               'itemsize':8})
+        assert_raises(ValueError, a.view, np.dtype([]))
+
+        d = np.dtype((np.dtype([]), 10))
+        assert_equal(d.shape, (10,))
+        assert_equal(d.itemsize, 0)
+        assert_equal(d.base, np.dtype([]))
+
+        arr = np.fromiter((() for i in range(10)), [])
+        assert_equal(arr.dtype, np.dtype([]))
+        assert_raises(ValueError, np.frombuffer, b'', dtype=[])
+        assert_equal(np.frombuffer(b'', dtype=[], count=2),
+                     np.empty(2, dtype=[]))
+
+        assert_raises(ValueError, np.dtype, ([], 'f8'))
+        assert_raises(ValueError, np.zeros(1, dtype='i4').view, [])
+
+        assert_equal(np.zeros(2, dtype=[]) == np.zeros(2, dtype=[]),
+                     np.ones(2, dtype=bool))
+
+        assert_equal(np.zeros((1, 2), dtype=[]) == a,
+                     np.ones((1, 2), dtype=bool))
+
+
+class TestSubarray:
+    def test_single_subarray(self):
+        a = np.dtype((int, (2)))
+        b = np.dtype((int, (2,)))
+        assert_dtype_equal(a, b)
+
+        assert_equal(type(a.subdtype[1]), tuple)
+        assert_equal(type(b.subdtype[1]), tuple)
+
+    def test_equivalent_record(self):
+        """Test whether equivalent subarray dtypes hash the same."""
+        a = np.dtype((int, (2, 3)))
+        b = np.dtype((int, (2, 3)))
+        assert_dtype_equal(a, b)
+
+    def test_nonequivalent_record(self):
+        """Test whether different subarray dtypes hash differently."""
+        a = np.dtype((int, (2, 3)))
+        b = np.dtype((int, (3, 2)))
+        assert_dtype_not_equal(a, b)
+
+        a = np.dtype((int, (2, 3)))
+        b = np.dtype((int, (2, 2)))
+        assert_dtype_not_equal(a, b)
+
+        a = np.dtype((int, (1, 2, 3)))
+        b = np.dtype((int, (1, 2)))
+        assert_dtype_not_equal(a, b)
+
+    def test_shape_equal(self):
+        """Test some data types that are equal"""
+        assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', tuple())))
+        # FutureWarning during deprecation period; after it is passed this
+        # should instead check that "(1)f8" == "1f8" == ("f8", 1).
+        with pytest.warns(FutureWarning):
+            assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', 1)))
+        assert_dtype_equal(np.dtype((int, 2)), np.dtype((int, (2,))))
+        assert_dtype_equal(np.dtype(('<f4', (3, 2))), np.dtype(('<f4', (3, 2))))
+        d = ([('a', 'f4', (1, 2)), ('b', 'f8', (3, 1))], (3, 2))
+        assert_dtype_equal(np.dtype(d), np.dtype(d))
+
+    def test_shape_simple(self):
+        """Test some simple cases that shouldn't be equal"""
+        assert_dtype_not_equal(np.dtype('f8'), np.dtype(('f8', (1,))))
+        assert_dtype_not_equal(np.dtype(('f8', (1,))), np.dtype(('f8', (1, 1))))
+        assert_dtype_not_equal(np.dtype(('f4', (3, 2))), np.dtype(('f4', (2, 3))))
+
+    def test_shape_monster(self):
+        """Test some more complicated cases that shouldn't be equal"""
+        assert_dtype_not_equal(
+            np.dtype(([('a', 'f4', (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
+            np.dtype(([('a', 'f4', (1, 2)), ('b', 'f8', (1, 3))], (2, 2))))
+        assert_dtype_not_equal(
+            np.dtype(([('a', 'f4', (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
+            np.dtype(([('a', 'f4', (2, 1)), ('b', 'i8', (1, 3))], (2, 2))))
+        assert_dtype_not_equal(
+            np.dtype(([('a', 'f4', (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
+            np.dtype(([('e', 'f8', (1, 3)), ('d', 'f4', (2, 1))], (2, 2))))
+        assert_dtype_not_equal(
+            np.dtype(([('a', [('a', 'i4', 6)], (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
+            np.dtype(([('a', [('a', 'u4', 6)], (2, 1)), ('b', 'f8', (1, 3))], (2, 2))))
+
+    def test_shape_sequence(self):
+        # Any sequence of integers should work as shape, but the result
+        # should be a tuple (immutable) of base type integers.
+        a = np.array([1, 2, 3], dtype=np.int16)
+        l = [1, 2, 3]
+        # Array gets converted
+        dt = np.dtype([('a', 'f4', a)])
+        assert_(isinstance(dt['a'].shape, tuple))
+        assert_(isinstance(dt['a'].shape[0], int))
+        # List gets converted
+        dt = np.dtype([('a', 'f4', l)])
+        assert_(isinstance(dt['a'].shape, tuple))
+        #
+
+        class IntLike:
+            def __index__(self):
+                return 3
+
+            def __int__(self):
+                # (a PyNumber_Check fails without __int__)
+                return 3
+
+        dt = np.dtype([('a', 'f4', IntLike())])
+        assert_(isinstance(dt['a'].shape, tuple))
+        assert_(isinstance(dt['a'].shape[0], int))
+        dt = np.dtype([('a', 'f4', (IntLike(),))])
+        assert_(isinstance(dt['a'].shape, tuple))
+        assert_(isinstance(dt['a'].shape[0], int))
+
+    def test_shape_matches_ndim(self):
+        dt = np.dtype([('a', 'f4', ())])
+        assert_equal(dt['a'].shape, ())
+        assert_equal(dt['a'].ndim, 0)
+
+        dt = np.dtype([('a', 'f4')])
+        assert_equal(dt['a'].shape, ())
+        assert_equal(dt['a'].ndim, 0)
+
+        dt = np.dtype([('a', 'f4', 4)])
+        assert_equal(dt['a'].shape, (4,))
+        assert_equal(dt['a'].ndim, 1)
+
+        dt = np.dtype([('a', 'f4', (1, 2, 3))])
+        assert_equal(dt['a'].shape, (1, 2, 3))
+        assert_equal(dt['a'].ndim, 3)
+
+    def test_shape_invalid(self):
+        # Check that the shape is valid.
+        max_int = np.iinfo(np.intc).max
+        max_intp = np.iinfo(np.intp).max
+        # Too large values (the datatype is part of this)
+        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int // 4 + 1)])
+        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int + 1)])
+        assert_raises(ValueError, np.dtype, [('a', 'f4', (max_int, 2))])
+        # Takes a different code path (fails earlier:
+        assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp + 1)])
+        # Negative values
+        assert_raises(ValueError, np.dtype, [('a', 'f4', -1)])
+        assert_raises(ValueError, np.dtype, [('a', 'f4', (-1, -1))])
+
+    def test_alignment(self):
+        #Check that subarrays are aligned
+        t1 = np.dtype('(1,)i4', align=True)
+        t2 = np.dtype('2i4', align=True)
+        assert_equal(t1.alignment, t2.alignment)
+
+    def test_aligned_empty(self):
+        # Mainly regression test for gh-19696: construction failed completely
+        dt = np.dtype([], align=True)
+        assert dt == np.dtype([])
+        dt = np.dtype({"names": [], "formats": [], "itemsize": 0}, align=True)
+        assert dt == np.dtype([])
+
+    def test_subarray_base_item(self):
+        arr = np.ones(3, dtype=[("f", "i", 3)])
+        # Extracting the field "absorbs" the subarray into a view:
+        assert arr["f"].base is arr
+        # Extract the structured item, and then check the tuple component:
+        item = arr.item(0)
+        assert type(item) is tuple and len(item) == 1
+        assert item[0].base is arr
+
+    def test_subarray_cast_copies(self):
+        # Older versions of NumPy did NOT copy, but they got the ownership
+        # wrong (not actually knowing the correct base!).  Versions since 1.21
+        # (I think) crashed fairly reliable.  This defines the correct behavior
+        # as a copy.  Keeping the ownership would be possible (but harder)
+        arr = np.ones(3, dtype=[("f", "i", 3)])
+        cast = arr.astype(object)
+        for fields in cast:
+            assert type(fields) == tuple and len(fields) == 1
+            subarr = fields[0]
+            assert subarr.base is None
+            assert subarr.flags.owndata
+
+
+def iter_struct_object_dtypes():
+    """
+    Iterates over a few complex dtypes and object pattern which
+    fill the array with a given object (defaults to a singleton).
+
+    Yields
+    ------
+    dtype : dtype
+    pattern : tuple
+        Structured tuple for use with `np.array`.
+    count : int
+        Number of objects stored in the dtype.
+    singleton : object
+        A singleton object. The returned pattern is constructed so that
+        all objects inside the datatype are set to the singleton.
+    """
+    obj = object()
+
+    dt = np.dtype([('b', 'O', (2, 3))])
+    p = ([[obj] * 3] * 2,)
+    yield pytest.param(dt, p, 6, obj, id="<subarray>")
+
+    dt = np.dtype([('a', 'i4'), ('b', 'O', (2, 3))])
+    p = (0, [[obj] * 3] * 2)
+    yield pytest.param(dt, p, 6, obj, id="<subarray in field>")
+
+    dt = np.dtype([('a', 'i4'),
+                   ('b', [('ba', 'O'), ('bb', 'i1')], (2, 3))])
+    p = (0, [[(obj, 0)] * 3] * 2)
+    yield pytest.param(dt, p, 6, obj, id="<structured subarray 1>")
+
+    dt = np.dtype([('a', 'i4'),
+                   ('b', [('ba', 'O'), ('bb', 'O')], (2, 3))])
+    p = (0, [[(obj, obj)] * 3] * 2)
+    yield pytest.param(dt, p, 12, obj, id="<structured subarray 2>")
+
+
+@pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+class TestStructuredObjectRefcounting:
+    """These tests cover various uses of complicated structured types which
+    include objects and thus require reference counting.
+    """
+    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
+                             iter_struct_object_dtypes())
+    @pytest.mark.parametrize(["creation_func", "creation_obj"], [
+        pytest.param(np.empty, None,
+             # None is probably used for too many things
+             marks=pytest.mark.skip("unreliable due to python's behaviour")),
+        (np.ones, 1),
+        (np.zeros, 0)])
+    def test_structured_object_create_delete(self, dt, pat, count, singleton,
+                                             creation_func, creation_obj):
+        """Structured object reference counting in creation and deletion"""
+        # The test assumes that 0, 1, and None are singletons.
+        gc.collect()
+        before = sys.getrefcount(creation_obj)
+        arr = creation_func(3, dt)
+
+        now = sys.getrefcount(creation_obj)
+        assert now - before == count * 3
+        del arr
+        now = sys.getrefcount(creation_obj)
+        assert now == before
+
+    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
+                             iter_struct_object_dtypes())
+    def test_structured_object_item_setting(self, dt, pat, count, singleton):
+        """Structured object reference counting for simple item setting"""
+        one = 1
+
+        gc.collect()
+        before = sys.getrefcount(singleton)
+        arr = np.array([pat] * 3, dt)
+        assert sys.getrefcount(singleton) - before == count * 3
+        # Fill with `1` and check that it was replaced correctly:
+        before2 = sys.getrefcount(one)
+        arr[...] = one
+        after2 = sys.getrefcount(one)
+        assert after2 - before2 == count * 3
+        del arr
+        gc.collect()
+        assert sys.getrefcount(one) == before2
+        assert sys.getrefcount(singleton) == before
+
+    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
+                             iter_struct_object_dtypes())
+    @pytest.mark.parametrize(
+        ['shape', 'index', 'items_changed'],
+        [((3,), ([0, 2],), 2),
+         ((3, 2), ([0, 2], slice(None)), 4),
+         ((3, 2), ([0, 2], [1]), 2),
+         ((3,), ([True, False, True]), 2)])
+    def test_structured_object_indexing(self, shape, index, items_changed,
+                                        dt, pat, count, singleton):
+        """Structured object reference counting for advanced indexing."""
+        # Use two small negative values (should be singletons, but less likely
+        # to run into race-conditions).  This failed in some threaded envs
+        # When using 0 and 1.  If it fails again, should remove all explicit
+        # checks, and rely on `pytest-leaks` reference count checker only.
+        val0 = -4
+        val1 = -5
+
+        arr = np.full(shape, val0, dt)
+
+        gc.collect()
+        before_val0 = sys.getrefcount(val0)
+        before_val1 = sys.getrefcount(val1)
+        # Test item getting:
+        part = arr[index]
+        after_val0 = sys.getrefcount(val0)
+        assert after_val0 - before_val0 == count * items_changed
+        del part
+        # Test item setting:
+        arr[index] = val1
+        gc.collect()
+        after_val0 = sys.getrefcount(val0)
+        after_val1 = sys.getrefcount(val1)
+        assert before_val0 - after_val0 == count * items_changed
+        assert after_val1 - before_val1 == count * items_changed
+
+    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
+                             iter_struct_object_dtypes())
+    def test_structured_object_take_and_repeat(self, dt, pat, count, singleton):
+        """Structured object reference counting for specialized functions.
+        The older functions such as take and repeat use different code paths
+        then item setting (when writing this).
+        """
+        indices = [0, 1]
+
+        arr = np.array([pat] * 3, dt)
+        gc.collect()
+        before = sys.getrefcount(singleton)
+        res = arr.take(indices)
+        after = sys.getrefcount(singleton)
+        assert after - before == count * 2
+        new = res.repeat(10)
+        gc.collect()
+        after_repeat = sys.getrefcount(singleton)
+        assert after_repeat - after == count * 2 * 10
+
+
+class TestStructuredDtypeSparseFields:
+    """Tests subarray fields which contain sparse dtypes so that
+    not all memory is used by the dtype work. Such dtype's should
+    leave the underlying memory unchanged.
+    """
+    dtype = np.dtype([('a', {'names':['aa', 'ab'], 'formats':['f', 'f'],
+                             'offsets':[0, 4]}, (2, 3))])
+    sparse_dtype = np.dtype([('a', {'names':['ab'], 'formats':['f'],
+                                    'offsets':[4]}, (2, 3))])
+
+    def test_sparse_field_assignment(self):
+        arr = np.zeros(3, self.dtype)
+        sparse_arr = arr.view(self.sparse_dtype)
+
+        sparse_arr[...] = np.finfo(np.float32).max
+        # dtype is reduced when accessing the field, so shape is (3, 2, 3):
+        assert_array_equal(arr["a"]["aa"], np.zeros((3, 2, 3)))
+
+    def test_sparse_field_assignment_fancy(self):
+        # Fancy assignment goes to the copyswap function for complex types:
+        arr = np.zeros(3, self.dtype)
+        sparse_arr = arr.view(self.sparse_dtype)
+
+        sparse_arr[[0, 1, 2]] = np.finfo(np.float32).max
+        # dtype is reduced when accessing the field, so shape is (3, 2, 3):
+        assert_array_equal(arr["a"]["aa"], np.zeros((3, 2, 3)))
+
+
+class TestMonsterType:
+    """Test deeply nested subtypes."""
+
+    def test1(self):
+        simple1 = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
+            'titles': ['Red pixel', 'Blue pixel']})
+        a = np.dtype([('yo', int), ('ye', simple1),
+            ('yi', np.dtype((int, (3, 2))))])
+        b = np.dtype([('yo', int), ('ye', simple1),
+            ('yi', np.dtype((int, (3, 2))))])
+        assert_dtype_equal(a, b)
+
+        c = np.dtype([('yo', int), ('ye', simple1),
+            ('yi', np.dtype((a, (3, 2))))])
+        d = np.dtype([('yo', int), ('ye', simple1),
+            ('yi', np.dtype((a, (3, 2))))])
+        assert_dtype_equal(c, d)
+
+    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    def test_list_recursion(self):
+        l = list()
+        l.append(('f', l))
+        with pytest.raises(RecursionError):
+            np.dtype(l)
+
+    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    def test_tuple_recursion(self):
+        d = np.int32
+        for i in range(100000):
+            d = (d, (1,))
+        with pytest.raises(RecursionError):
+            np.dtype(d)
+
+    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    def test_dict_recursion(self):
+        d = dict(names=['self'], formats=[None], offsets=[0])
+        d['formats'][0] = d
+        with pytest.raises(RecursionError):
+            np.dtype(d)
+
+
+class TestMetadata:
+    def test_no_metadata(self):
+        d = np.dtype(int)
+        assert_(d.metadata is None)
+
+    def test_metadata_takes_dict(self):
+        d = np.dtype(int, metadata={'datum': 1})
+        assert_(d.metadata == {'datum': 1})
+
+    def test_metadata_rejects_nondict(self):
+        assert_raises(TypeError, np.dtype, int, metadata='datum')
+        assert_raises(TypeError, np.dtype, int, metadata=1)
+        assert_raises(TypeError, np.dtype, int, metadata=None)
+
+    def test_nested_metadata(self):
+        d = np.dtype([('a', np.dtype(int, metadata={'datum': 1}))])
+        assert_(d['a'].metadata == {'datum': 1})
+
+    def test_base_metadata_copied(self):
+        d = np.dtype((np.void, np.dtype('i4,i4', metadata={'datum': 1})))
+        assert_(d.metadata == {'datum': 1})
+
+class TestString:
+    def test_complex_dtype_str(self):
+        dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
+                                ('rtile', '>f4', (64, 36))], (3,)),
+                       ('bottom', [('bleft', ('>f4', (8, 64)), (1,)),
+                                   ('bright', '>f4', (8, 36))])])
+        assert_equal(str(dt),
+                     "[('top', [('tiles', ('>f4', (64, 64)), (1,)), "
+                     "('rtile', '>f4', (64, 36))], (3,)), "
+                     "('bottom', [('bleft', ('>f4', (8, 64)), (1,)), "
+                     "('bright', '>f4', (8, 36))])]")
+
+        # If the sticky aligned flag is set to True, it makes the
+        # str() function use a dict representation with an 'aligned' flag
+        dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
+                                ('rtile', '>f4', (64, 36))],
+                                (3,)),
+                       ('bottom', [('bleft', ('>f4', (8, 64)), (1,)),
+                                   ('bright', '>f4', (8, 36))])],
+                       align=True)
+        assert_equal(str(dt),
+                    "{'names': ['top', 'bottom'],"
+                    " 'formats': [([('tiles', ('>f4', (64, 64)), (1,)), "
+                                   "('rtile', '>f4', (64, 36))], (3,)), "
+                                  "[('bleft', ('>f4', (8, 64)), (1,)), "
+                                   "('bright', '>f4', (8, 36))]],"
+                    " 'offsets': [0, 76800],"
+                    " 'itemsize': 80000,"
+                    " 'aligned': True}")
+        with np.printoptions(legacy='1.21'):
+            assert_equal(str(dt),
+                        "{'names':['top','bottom'], "
+                         "'formats':[([('tiles', ('>f4', (64, 64)), (1,)), "
+                                      "('rtile', '>f4', (64, 36))], (3,)),"
+                                     "[('bleft', ('>f4', (8, 64)), (1,)), "
+                                      "('bright', '>f4', (8, 36))]], "
+                         "'offsets':[0,76800], "
+                         "'itemsize':80000, "
+                         "'aligned':True}")
+        assert_equal(np.dtype(eval(str(dt))), dt)
+
+        dt = np.dtype({'names': ['r', 'g', 'b'], 'formats': ['u1', 'u1', 'u1'],
+                        'offsets': [0, 1, 2],
+                        'titles': ['Red pixel', 'Green pixel', 'Blue pixel']})
+        assert_equal(str(dt),
+                    "[(('Red pixel', 'r'), 'u1'), "
+                    "(('Green pixel', 'g'), 'u1'), "
+                    "(('Blue pixel', 'b'), 'u1')]")
+
+        dt = np.dtype({'names': ['rgba', 'r', 'g', 'b'],
+                       'formats': ['<u4', 'u1', 'u1', 'u1'],
+                       'offsets': [0, 0, 1, 2],
+                       'titles': ['Color', 'Red pixel',
+                                  'Green pixel', 'Blue pixel']})
+        assert_equal(str(dt),
+                    "{'names': ['rgba', 'r', 'g', 'b'],"
+                    " 'formats': ['<u4', 'u1', 'u1', 'u1'],"
+                    " 'offsets': [0, 0, 1, 2],"
+                    " 'titles': ['Color', 'Red pixel', "
+                               "'Green pixel', 'Blue pixel'],"
+                    " 'itemsize': 4}")
+
+        dt = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
+                        'offsets': [0, 2],
+                        'titles': ['Red pixel', 'Blue pixel']})
+        assert_equal(str(dt),
+                    "{'names': ['r', 'b'],"
+                    " 'formats': ['u1', 'u1'],"
+                    " 'offsets': [0, 2],"
+                    " 'titles': ['Red pixel', 'Blue pixel'],"
+                    " 'itemsize': 3}")
+
+        dt = np.dtype([('a', '<m8[D]'), ('b', '<M8[us]')])
+        assert_equal(str(dt),
+                    "[('a', '<m8[D]'), ('b', '<M8[us]')]")
+
+    def test_repr_structured(self):
+        dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
+                                ('rtile', '>f4', (64, 36))], (3,)),
+                       ('bottom', [('bleft', ('>f4', (8, 64)), (1,)),
+                                   ('bright', '>f4', (8, 36))])])
+        assert_equal(repr(dt),
+                     "dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)), "
+                     "('rtile', '>f4', (64, 36))], (3,)), "
+                     "('bottom', [('bleft', ('>f4', (8, 64)), (1,)), "
+                     "('bright', '>f4', (8, 36))])])")
+
+        dt = np.dtype({'names': ['r', 'g', 'b'], 'formats': ['u1', 'u1', 'u1'],
+                        'offsets': [0, 1, 2],
+                        'titles': ['Red pixel', 'Green pixel', 'Blue pixel']},
+                        align=True)
+        assert_equal(repr(dt),
+                    "dtype([(('Red pixel', 'r'), 'u1'), "
+                    "(('Green pixel', 'g'), 'u1'), "
+                    "(('Blue pixel', 'b'), 'u1')], align=True)")
+
+    def test_repr_structured_not_packed(self):
+        dt = np.dtype({'names': ['rgba', 'r', 'g', 'b'],
+                       'formats': ['<u4', 'u1', 'u1', 'u1'],
+                       'offsets': [0, 0, 1, 2],
+                       'titles': ['Color', 'Red pixel',
+                                  'Green pixel', 'Blue pixel']}, align=True)
+        assert_equal(repr(dt),
+                    "dtype({'names': ['rgba', 'r', 'g', 'b'],"
+                    " 'formats': ['<u4', 'u1', 'u1', 'u1'],"
+                    " 'offsets': [0, 0, 1, 2],"
+                    " 'titles': ['Color', 'Red pixel', "
+                                "'Green pixel', 'Blue pixel'],"
+                    " 'itemsize': 4}, align=True)")
+
+        dt = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
+                        'offsets': [0, 2],
+                        'titles': ['Red pixel', 'Blue pixel'],
+                        'itemsize': 4})
+        assert_equal(repr(dt),
+                    "dtype({'names': ['r', 'b'], "
+                    "'formats': ['u1', 'u1'], "
+                    "'offsets': [0, 2], "
+                    "'titles': ['Red pixel', 'Blue pixel'], "
+                    "'itemsize': 4})")
+
+    def test_repr_structured_datetime(self):
+        dt = np.dtype([('a', '<M8[D]'), ('b', '<m8[us]')])
+        assert_equal(repr(dt),
+                    "dtype([('a', '<M8[D]'), ('b', '<m8[us]')])")
+
+    def test_repr_str_subarray(self):
+        dt = np.dtype(('<i2', (1,)))
+        assert_equal(repr(dt), "dtype(('<i2', (1,)))")
+        assert_equal(str(dt), "('<i2', (1,))")
+
+    def test_base_dtype_with_object_type(self):
+        # Issue gh-2798, should not error.
+        np.array(['a'], dtype="O").astype(("O", [("name", "O")]))
+
+    def test_empty_string_to_object(self):
+        # Pull request #4722
+        np.array(["", ""]).astype(object)
+
+    def test_void_subclass_unsized(self):
+        dt = np.dtype(np.record)
+        assert_equal(repr(dt), "dtype('V')")
+        assert_equal(str(dt), '|V0')
+        assert_equal(dt.name, 'record')
+
+    def test_void_subclass_sized(self):
+        dt = np.dtype((np.record, 2))
+        assert_equal(repr(dt), "dtype('V2')")
+        assert_equal(str(dt), '|V2')
+        assert_equal(dt.name, 'record16')
+
+    def test_void_subclass_fields(self):
+        dt = np.dtype((np.record, [('a', '<u2')]))
+        assert_equal(repr(dt), "dtype((numpy.record, [('a', '<u2')]))")
+        assert_equal(str(dt), "(numpy.record, [('a', '<u2')])")
+        assert_equal(dt.name, 'record16')
+
+
+class TestDtypeAttributeDeletion:
+
+    def test_dtype_non_writable_attributes_deletion(self):
+        dt = np.dtype(np.double)
+        attr = ["subdtype", "descr", "str", "name", "base", "shape",
+                "isbuiltin", "isnative", "isalignedstruct", "fields",
+                "metadata", "hasobject"]
+
+        for s in attr:
+            assert_raises(AttributeError, delattr, dt, s)
+
+    def test_dtype_writable_attributes_deletion(self):
+        dt = np.dtype(np.double)
+        attr = ["names"]
+        for s in attr:
+            assert_raises(AttributeError, delattr, dt, s)
+
+
+class TestDtypeAttributes:
+    def test_descr_has_trailing_void(self):
+        # see gh-6359
+        dtype = np.dtype({
+            'names': ['A', 'B'],
+            'formats': ['f4', 'f4'],
+            'offsets': [0, 8],
+            'itemsize': 16})
+        new_dtype = np.dtype(dtype.descr)
+        assert_equal(new_dtype.itemsize, 16)
+
+    def test_name_dtype_subclass(self):
+        # Ticket #4357
+        class user_def_subcls(np.void):
+            pass
+        assert_equal(np.dtype(user_def_subcls).name, 'user_def_subcls')
+
+    def test_zero_stride(self):
+        arr = np.ones(1, dtype="i8")
+        arr = np.broadcast_to(arr, 10)
+        assert arr.strides == (0,)
+        with pytest.raises(ValueError):
+            arr.dtype = "i1"
+
+class TestDTypeMakeCanonical:
+    def check_canonical(self, dtype, canonical):
+        """
+        Check most properties relevant to "canonical" versions of a dtype,
+        which is mainly native byte order for datatypes supporting this.
+
+        The main work is checking structured dtypes with fields, where we
+        reproduce most the actual logic used in the C-code.
+        """
+        assert type(dtype) is type(canonical)
+
+        # a canonical DType should always have equivalent casting (both ways)
+        assert np.can_cast(dtype, canonical, casting="equiv")
+        assert np.can_cast(canonical, dtype, casting="equiv")
+        # a canonical dtype (and its fields) is always native (checks fields):
+        assert canonical.isnative
+
+        # Check that canonical of canonical is the same (no casting):
+        assert np.result_type(canonical) == canonical
+
+        if not dtype.names:
+            # The flags currently never change for unstructured dtypes
+            assert dtype.flags == canonical.flags
+            return
+
+        # Must have all the needs API flag set:
+        assert dtype.flags & 0b10000
+
+        # Check that the fields are identical (including titles):
+        assert dtype.fields.keys() == canonical.fields.keys()
+
+        def aligned_offset(offset, alignment):
+            # round up offset:
+            return - (-offset // alignment) * alignment
+
+        totalsize = 0
+        max_alignment = 1
+        for name in dtype.names:
+            # each field is also canonical:
+            new_field_descr = canonical.fields[name][0]
+            self.check_canonical(dtype.fields[name][0], new_field_descr)
+
+            # Must have the "inherited" object related flags:
+            expected = 0b11011 & new_field_descr.flags
+            assert (canonical.flags & expected) == expected
+
+            if canonical.isalignedstruct:
+                totalsize = aligned_offset(totalsize, new_field_descr.alignment)
+                max_alignment = max(new_field_descr.alignment, max_alignment)
+
+            assert canonical.fields[name][1] == totalsize
+            # if a title exists, they must match (otherwise empty tuple):
+            assert dtype.fields[name][2:] == canonical.fields[name][2:]
+
+            totalsize += new_field_descr.itemsize
+
+        if canonical.isalignedstruct:
+            totalsize = aligned_offset(totalsize, max_alignment)
+        assert canonical.itemsize == totalsize
+        assert canonical.alignment == max_alignment
+
+    def test_simple(self):
+        dt = np.dtype(">i4")
+        assert np.result_type(dt).isnative
+        assert np.result_type(dt).num == dt.num
+
+        # dtype with empty space:
+        struct_dt = np.dtype(">i4,<i1,i8,V3")[["f0", "f2"]]
+        canonical = np.result_type(struct_dt)
+        assert canonical.itemsize == 4+8
+        assert canonical.isnative
+
+        # aligned struct dtype with empty space:
+        struct_dt = np.dtype(">i1,<i4,i8,V3", align=True)[["f0", "f2"]]
+        canonical = np.result_type(struct_dt)
+        assert canonical.isalignedstruct
+        assert canonical.itemsize == np.dtype("i8").alignment + 8
+        assert canonical.isnative
+
+    def test_object_flag_not_inherited(self):
+        # The following dtype still indicates "object", because its included
+        # in the unaccessible space (maybe this could change at some point):
+        arr = np.ones(3, "i,O,i")[["f0", "f2"]]
+        assert arr.dtype.hasobject
+        canonical_dt = np.result_type(arr.dtype)
+        assert not canonical_dt.hasobject
+
+    @pytest.mark.slow
+    @hypothesis.given(dtype=hynp.nested_dtypes())
+    def test_make_canonical_hypothesis(self, dtype):
+        canonical = np.result_type(dtype)
+        self.check_canonical(dtype, canonical)
+        # result_type with two arguments should always give identical results:
+        two_arg_result = np.result_type(dtype, dtype)
+        assert np.can_cast(two_arg_result, canonical, casting="no")
+
+    @pytest.mark.slow
+    @hypothesis.given(
+            dtype=hypothesis.extra.numpy.array_dtypes(
+                subtype_strategy=hypothesis.extra.numpy.array_dtypes(),
+                min_size=5, max_size=10, allow_subarrays=True))
+    def test_structured(self, dtype):
+        # Pick 4 of the fields at random.  This will leave empty space in the
+        # dtype (since we do not canonicalize it here).
+        field_subset = random.sample(dtype.names, k=4)
+        dtype_with_empty_space = dtype[field_subset]
+        assert dtype_with_empty_space.itemsize == dtype.itemsize
+        canonicalized = np.result_type(dtype_with_empty_space)
+        self.check_canonical(dtype_with_empty_space, canonicalized)
+        # promotion with two arguments should always give identical results:
+        two_arg_result = np.promote_types(
+                dtype_with_empty_space, dtype_with_empty_space)
+        assert np.can_cast(two_arg_result, canonicalized, casting="no")
+
+        # Ensure that we also check aligned struct (check the opposite, in
+        # case hypothesis grows support for `align`.  Then repeat the test:
+        dtype_aligned = np.dtype(dtype.descr, align=not dtype.isalignedstruct)
+        dtype_with_empty_space = dtype_aligned[field_subset]
+        assert dtype_with_empty_space.itemsize == dtype_aligned.itemsize
+        canonicalized = np.result_type(dtype_with_empty_space)
+        self.check_canonical(dtype_with_empty_space, canonicalized)
+        # promotion with two arguments should always give identical results:
+        two_arg_result = np.promote_types(
+            dtype_with_empty_space, dtype_with_empty_space)
+        assert np.can_cast(two_arg_result, canonicalized, casting="no")
+
+
+class TestPickling:
+
+    def check_pickling(self, dtype):
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            buf = pickle.dumps(dtype, proto)
+            # The dtype pickling itself pickles `np.dtype` if it is pickled
+            # as a singleton `dtype` should be stored in the buffer:
+            assert b"_DType_reconstruct" not in buf
+            assert b"dtype" in buf
+            pickled = pickle.loads(buf)
+            assert_equal(pickled, dtype)
+            assert_equal(pickled.descr, dtype.descr)
+            if dtype.metadata is not None:
+                assert_equal(pickled.metadata, dtype.metadata)
+            # Check the reconstructed dtype is functional
+            x = np.zeros(3, dtype=dtype)
+            y = np.zeros(3, dtype=pickled)
+            assert_equal(x, y)
+            assert_equal(x[0], y[0])
+
+    @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
+                                   np.compat.unicode, bool])
+    def test_builtin(self, t):
+        self.check_pickling(np.dtype(t))
+
+    def test_structured(self):
+        dt = np.dtype(([('a', '>f4', (2, 1)), ('b', '<f8', (1, 3))], (2, 2)))
+        self.check_pickling(dt)
+
+    def test_structured_aligned(self):
+        dt = np.dtype('i4, i1', align=True)
+        self.check_pickling(dt)
+
+    def test_structured_unaligned(self):
+        dt = np.dtype('i4, i1', align=False)
+        self.check_pickling(dt)
+
+    def test_structured_padded(self):
+        dt = np.dtype({
+            'names': ['A', 'B'],
+            'formats': ['f4', 'f4'],
+            'offsets': [0, 8],
+            'itemsize': 16})
+        self.check_pickling(dt)
+
+    def test_structured_titles(self):
+        dt = np.dtype({'names': ['r', 'b'],
+                       'formats': ['u1', 'u1'],
+                       'titles': ['Red pixel', 'Blue pixel']})
+        self.check_pickling(dt)
+
+    @pytest.mark.parametrize('base', ['m8', 'M8'])
+    @pytest.mark.parametrize('unit', ['', 'Y', 'M', 'W', 'D', 'h', 'm', 's',
+                                      'ms', 'us', 'ns', 'ps', 'fs', 'as'])
+    def test_datetime(self, base, unit):
+        dt = np.dtype('%s[%s]' % (base, unit) if unit else base)
+        self.check_pickling(dt)
+        if unit:
+            dt = np.dtype('%s[7%s]' % (base, unit))
+            self.check_pickling(dt)
+
+    def test_metadata(self):
+        dt = np.dtype(int, metadata={'datum': 1})
+        self.check_pickling(dt)
+
+    @pytest.mark.parametrize("DType",
+        [type(np.dtype(t)) for t in np.typecodes['All']] +
+        [np.dtype(rational), np.dtype])
+    def test_pickle_types(self, DType):
+        # Check that DTypes (the classes/types) roundtrip when pickling
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            roundtrip_DType = pickle.loads(pickle.dumps(DType, proto))
+            assert roundtrip_DType is DType
+
+
+class TestPromotion:
+    """Test cases related to more complex DType promotions.  Further promotion
+    tests are defined in `test_numeric.py`
+    """
+    @np._no_nep50_warning()
+    @pytest.mark.parametrize(["other", "expected", "expected_weak"],
+            [(2**16-1, np.complex64, None),
+             (2**32-1, np.complex128, np.complex64),
+             (np.float16(2), np.complex64, None),
+             (np.float32(2), np.complex64, None),
+             (np.longdouble(2), np.complex64, np.clongdouble),
+             # Base of the double value to sidestep any rounding issues:
+             (np.longdouble(np.nextafter(1.7e308, 0.)),
+                  np.complex128, np.clongdouble),
+             # Additionally use "nextafter" so the cast can't round down:
+             (np.longdouble(np.nextafter(1.7e308, np.inf)),
+                  np.clongdouble, None),
+             # repeat for complex scalars:
+             (np.complex64(2), np.complex64, None),
+             (np.clongdouble(2), np.complex64, np.clongdouble),
+             # Base of the double value to sidestep any rounding issues:
+             (np.clongdouble(np.nextafter(1.7e308, 0.) * 1j),
+                  np.complex128, np.clongdouble),
+             # Additionally use "nextafter" so the cast can't round down:
+             (np.clongdouble(np.nextafter(1.7e308, np.inf)),
+                  np.clongdouble, None),
+             ])
+    def test_complex_other_value_based(self,
+            weak_promotion, other, expected, expected_weak):
+        if weak_promotion and expected_weak is not None:
+            expected = expected_weak
+
+        # This would change if we modify the value based promotion
+        min_complex = np.dtype(np.complex64)
+
+        res = np.result_type(other, min_complex)
+        assert res == expected
+        # Check the same for a simple ufunc call that uses the same logic:
+        res = np.minimum(other, np.ones(3, dtype=min_complex)).dtype
+        assert res == expected
+
+    @pytest.mark.parametrize(["other", "expected"],
+                 [(np.bool_, np.complex128),
+                  (np.int64, np.complex128),
+                  (np.float16, np.complex64),
+                  (np.float32, np.complex64),
+                  (np.float64, np.complex128),
+                  (np.longdouble, np.clongdouble),
+                  (np.complex64, np.complex64),
+                  (np.complex128, np.complex128),
+                  (np.clongdouble, np.clongdouble),
+                  ])
+    def test_complex_scalar_value_based(self, other, expected):
+        # This would change if we modify the value based promotion
+        complex_scalar = 1j
+
+        res = np.result_type(other, complex_scalar)
+        assert res == expected
+        # Check the same for a simple ufunc call that uses the same logic:
+        res = np.minimum(np.ones(3, dtype=other), complex_scalar).dtype
+        assert res == expected
+
+    def test_complex_pyscalar_promote_rational(self):
+        with pytest.raises(TypeError,
+                match=r".* no common DType exists for the given inputs"):
+            np.result_type(1j, rational)
+
+        with pytest.raises(TypeError,
+                match=r".* no common DType exists for the given inputs"):
+            np.result_type(1j, rational(1, 2))
+
+    @pytest.mark.parametrize("val", [2, 2**32, 2**63, 2**64, 2*100])
+    def test_python_integer_promotion(self, val):
+        # If we only path scalars (mainly python ones!), the result must take
+        # into account that the integer may be considered int32, int64, uint64,
+        # or object depending on the input value.  So test those paths!
+        expected_dtype = np.result_type(np.array(val).dtype, np.array(0).dtype)
+        assert np.result_type(val, 0) == expected_dtype
+        # For completeness sake, also check with a NumPy scalar as second arg:
+        assert np.result_type(val, np.int8(0)) == expected_dtype
+
+    @pytest.mark.parametrize(["other", "expected"],
+            [(1, rational), (1., np.float64)])
+    @np._no_nep50_warning()
+    def test_float_int_pyscalar_promote_rational(
+            self, weak_promotion, other, expected):
+        # Note that rationals are a bit akward as they promote with float64
+        # or default ints, but not float16 or uint8/int8 (which looks
+        # inconsistent here).  The new promotion fixes this (partially?)
+        if not weak_promotion and type(other) == float:
+            # The float version, checks float16 in the legacy path, which fails
+            # the integer version seems to check int8 (also), so it can
+            # pass.
+            with pytest.raises(TypeError,
+                    match=r".* do not have a common DType"):
+                np.result_type(other, rational)
+        else:
+            assert np.result_type(other, rational) == expected
+
+        assert np.result_type(other, rational(1, 2)) == expected
+
+    @pytest.mark.parametrize(["dtypes", "expected"], [
+             # These promotions are not associative/commutative:
+             ([np.uint16, np.int16, np.float16], np.float32),
+             ([np.uint16, np.int8, np.float16], np.float32),
+             ([np.uint8, np.int16, np.float16], np.float32),
+             # The following promotions are not ambiguous, but cover code
+             # paths of abstract promotion (no particular logic being tested)
+             ([1, 1, np.float64], np.float64),
+             ([1, 1., np.complex128], np.complex128),
+             ([1, 1j, np.float64], np.complex128),
+             ([1., 1., np.int64], np.float64),
+             ([1., 1j, np.float64], np.complex128),
+             ([1j, 1j, np.float64], np.complex128),
+             ([1, True, np.bool_], np.int_),
+            ])
+    def test_permutations_do_not_influence_result(self, dtypes, expected):
+        # Tests that most permutations do not influence the result.  In the
+        # above some uint and int combintations promote to a larger integer
+        # type, which would then promote to a larger than necessary float.
+        for perm in permutations(dtypes):
+            assert np.result_type(*perm) == expected
+
+
+def test_rational_dtype():
+    # test for bug gh-5719
+    a = np.array([1111], dtype=rational).astype
+    assert_raises(OverflowError, a, 'int8')
+
+    # test that dtype detection finds user-defined types
+    x = rational(1)
+    assert_equal(np.array([x,x]).dtype, np.dtype(rational))
+
+
+def test_dtypes_are_true():
+    # test for gh-6294
+    assert bool(np.dtype('f8'))
+    assert bool(np.dtype('i8'))
+    assert bool(np.dtype([('a', 'i8'), ('b', 'f4')]))
+
+
+def test_invalid_dtype_string():
+    # test for gh-10440
+    assert_raises(TypeError, np.dtype, 'f8,i8,[f8,i8]')
+    assert_raises(TypeError, np.dtype, 'Fl\xfcgel')
+
+
+def test_keyword_argument():
+    # test for https://github.com/numpy/numpy/pull/16574#issuecomment-642660971
+    assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
+
+
+def test_ulong_dtype():
+    # test for gh-21063
+    assert np.dtype("ulong") == np.dtype(np.uint)
+
+
+class TestFromDTypeAttribute:
+    def test_simple(self):
+        class dt:
+            dtype = np.dtype("f8")
+
+        assert np.dtype(dt) == np.float64
+        assert np.dtype(dt()) == np.float64
+
+    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    def test_recursion(self):
+        class dt:
+            pass
+
+        dt.dtype = dt
+        with pytest.raises(RecursionError):
+            np.dtype(dt)
+
+        dt_instance = dt()
+        dt_instance.dtype = dt
+        with pytest.raises(RecursionError):
+            np.dtype(dt_instance)
+
+    def test_void_subtype(self):
+        class dt(np.void):
+            # This code path is fully untested before, so it is unclear
+            # what this should be useful for. Note that if np.void is used
+            # numpy will think we are deallocating a base type [1.17, 2019-02].
+            dtype = np.dtype("f,f")
+
+        np.dtype(dt)
+        np.dtype(dt(1))
+
+    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
+    def test_void_subtype_recursion(self):
+        class vdt(np.void):
+            pass
+
+        vdt.dtype = vdt
+
+        with pytest.raises(RecursionError):
+            np.dtype(vdt)
+
+        with pytest.raises(RecursionError):
+            np.dtype(vdt(1))
+
+
+class TestDTypeClasses:
+    @pytest.mark.parametrize("dtype", list(np.typecodes['All']) + [rational])
+    def test_basic_dtypes_subclass_properties(self, dtype):
+        # Note: Except for the isinstance and type checks, these attributes
+        #       are considered currently private and may change.
+        dtype = np.dtype(dtype)
+        assert isinstance(dtype, np.dtype)
+        assert type(dtype) is not np.dtype
+        assert type(dtype).__name__ == f"dtype[{dtype.type.__name__}]"
+        assert type(dtype).__module__ == "numpy"
+        assert not type(dtype)._abstract
+
+        # the flexible dtypes and datetime/timedelta have additional parameters
+        # which are more than just storage information, these would need to be
+        # given when creating a dtype:
+        parametric = (np.void, np.str_, np.bytes_, np.datetime64, np.timedelta64)
+        if dtype.type not in parametric:
+            assert not type(dtype)._parametric
+            assert type(dtype)() is dtype
+        else:
+            assert type(dtype)._parametric
+            with assert_raises(TypeError):
+                type(dtype)()
+
+    def test_dtype_superclass(self):
+        assert type(np.dtype) is not type
+        assert isinstance(np.dtype, type)
+
+        assert type(np.dtype).__name__ == "_DTypeMeta"
+        assert type(np.dtype).__module__ == "numpy"
+        assert np.dtype._abstract
+
+
+class TestFromCTypes:
+
+    @staticmethod
+    def check(ctype, dtype):
+        dtype = np.dtype(dtype)
+        assert_equal(np.dtype(ctype), dtype)
+        assert_equal(np.dtype(ctype()), dtype)
+
+    def test_array(self):
+        c8 = ctypes.c_uint8
+        self.check(     3 * c8,  (np.uint8, (3,)))
+        self.check(     1 * c8,  (np.uint8, (1,)))
+        self.check(     0 * c8,  (np.uint8, (0,)))
+        self.check(1 * (3 * c8), ((np.uint8, (3,)), (1,)))
+        self.check(3 * (1 * c8), ((np.uint8, (1,)), (3,)))
+
+    def test_padded_structure(self):
+        class PaddedStruct(ctypes.Structure):
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16)
+            ]
+        expected = np.dtype([
+            ('a', np.uint8),
+            ('b', np.uint16)
+        ], align=True)
+        self.check(PaddedStruct, expected)
+
+    def test_bit_fields(self):
+        class BitfieldStruct(ctypes.Structure):
+            _fields_ = [
+                ('a', ctypes.c_uint8, 7),
+                ('b', ctypes.c_uint8, 1)
+            ]
+        assert_raises(TypeError, np.dtype, BitfieldStruct)
+        assert_raises(TypeError, np.dtype, BitfieldStruct())
+
+    def test_pointer(self):
+        p_uint8 = ctypes.POINTER(ctypes.c_uint8)
+        assert_raises(TypeError, np.dtype, p_uint8)
+
+    def test_void_pointer(self):
+        self.check(ctypes.c_void_p, np.uintp)
+
+    def test_union(self):
+        class Union(ctypes.Union):
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16),
+            ]
+        expected = np.dtype(dict(
+            names=['a', 'b'],
+            formats=[np.uint8, np.uint16],
+            offsets=[0, 0],
+            itemsize=2
+        ))
+        self.check(Union, expected)
+
+    def test_union_with_struct_packed(self):
+        class Struct(ctypes.Structure):
+            _pack_ = 1
+            _fields_ = [
+                ('one', ctypes.c_uint8),
+                ('two', ctypes.c_uint32)
+            ]
+
+        class Union(ctypes.Union):
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16),
+                ('c', ctypes.c_uint32),
+                ('d', Struct),
+            ]
+        expected = np.dtype(dict(
+            names=['a', 'b', 'c', 'd'],
+            formats=['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
+            offsets=[0, 0, 0, 0],
+            itemsize=ctypes.sizeof(Union)
+        ))
+        self.check(Union, expected)
+
+    def test_union_packed(self):
+        class Struct(ctypes.Structure):
+            _fields_ = [
+                ('one', ctypes.c_uint8),
+                ('two', ctypes.c_uint32)
+            ]
+            _pack_ = 1
+        class Union(ctypes.Union):
+            _pack_ = 1
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16),
+                ('c', ctypes.c_uint32),
+                ('d', Struct),
+            ]
+        expected = np.dtype(dict(
+            names=['a', 'b', 'c', 'd'],
+            formats=['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
+            offsets=[0, 0, 0, 0],
+            itemsize=ctypes.sizeof(Union)
+        ))
+        self.check(Union, expected)
+
+    def test_packed_structure(self):
+        class PackedStructure(ctypes.Structure):
+            _pack_ = 1
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16)
+            ]
+        expected = np.dtype([
+            ('a', np.uint8),
+            ('b', np.uint16)
+        ])
+        self.check(PackedStructure, expected)
+
+    def test_large_packed_structure(self):
+        class PackedStructure(ctypes.Structure):
+            _pack_ = 2
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16),
+                ('c', ctypes.c_uint8),
+                ('d', ctypes.c_uint16),
+                ('e', ctypes.c_uint32),
+                ('f', ctypes.c_uint32),
+                ('g', ctypes.c_uint8)
+                ]
+        expected = np.dtype(dict(
+            formats=[np.uint8, np.uint16, np.uint8, np.uint16, np.uint32, np.uint32, np.uint8 ],
+            offsets=[0, 2, 4, 6, 8, 12, 16],
+            names=['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+            itemsize=18))
+        self.check(PackedStructure, expected)
+
+    def test_big_endian_structure_packed(self):
+        class BigEndStruct(ctypes.BigEndianStructure):
+            _fields_ = [
+                ('one', ctypes.c_uint8),
+                ('two', ctypes.c_uint32)
+            ]
+            _pack_ = 1
+        expected = np.dtype([('one', 'u1'), ('two', '>u4')])
+        self.check(BigEndStruct, expected)
+
+    def test_little_endian_structure_packed(self):
+        class LittleEndStruct(ctypes.LittleEndianStructure):
+            _fields_ = [
+                ('one', ctypes.c_uint8),
+                ('two', ctypes.c_uint32)
+            ]
+            _pack_ = 1
+        expected = np.dtype([('one', 'u1'), ('two', '<u4')])
+        self.check(LittleEndStruct, expected)
+
+    def test_little_endian_structure(self):
+        class PaddedStruct(ctypes.LittleEndianStructure):
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16)
+            ]
+        expected = np.dtype([
+            ('a', '<B'),
+            ('b', '<H')
+        ], align=True)
+        self.check(PaddedStruct, expected)
+
+    def test_big_endian_structure(self):
+        class PaddedStruct(ctypes.BigEndianStructure):
+            _fields_ = [
+                ('a', ctypes.c_uint8),
+                ('b', ctypes.c_uint16)
+            ]
+        expected = np.dtype([
+            ('a', '>B'),
+            ('b', '>H')
+        ], align=True)
+        self.check(PaddedStruct, expected)
+
+    def test_simple_endian_types(self):
+        self.check(ctypes.c_uint16.__ctype_le__, np.dtype('<u2'))
+        self.check(ctypes.c_uint16.__ctype_be__, np.dtype('>u2'))
+        self.check(ctypes.c_uint8.__ctype_le__, np.dtype('u1'))
+        self.check(ctypes.c_uint8.__ctype_be__, np.dtype('u1'))
+
+    all_types = set(np.typecodes['All'])
+    all_pairs = permutations(all_types, 2)
+
+    @pytest.mark.parametrize("pair", all_pairs)
+    def test_pairs(self, pair):
+        """
+        Check that np.dtype('x,y') matches [np.dtype('x'), np.dtype('y')]
+        Example: np.dtype('d,I') -> dtype([('f0', '<f8'), ('f1', '<u4')])
+        """
+        # gh-5645: check that np.dtype('i,L') can be used
+        pair_type = np.dtype('{},{}'.format(*pair))
+        expected = np.dtype([('f0', pair[0]), ('f1', pair[1])])
+        assert_equal(pair_type, expected)
+
+
+class TestUserDType:
+    @pytest.mark.leaks_references(reason="dynamically creates custom dtype.")
+    def test_custom_structured_dtype(self):
+        class mytype:
+            pass
+
+        blueprint = np.dtype([("field", object)])
+        dt = create_custom_field_dtype(blueprint, mytype, 0)
+        assert dt.type == mytype
+        # We cannot (currently) *create* this dtype with `np.dtype` because
+        # mytype does not inherit from `np.generic`.  This seems like an
+        # unnecessary restriction, but one that has been around forever:
+        assert np.dtype(mytype) == np.dtype("O")
+
+    def test_custom_structured_dtype_errors(self):
+        class mytype:
+            pass
+
+        blueprint = np.dtype([("field", object)])
+
+        with pytest.raises(ValueError):
+            # Tests what happens if fields are unset during creation
+            # which is currently rejected due to the containing object
+            # (see PyArray_RegisterDataType).
+            create_custom_field_dtype(blueprint, mytype, 1)
+
+        with pytest.raises(RuntimeError):
+            # Tests that a dtype must have its type field set up to np.dtype
+            # or in this case a builtin instance.
+            create_custom_field_dtype(blueprint, mytype, 2)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
+class TestClassGetItem:
+    def test_dtype(self) -> None:
+        alias = np.dtype[Any]
+        assert isinstance(alias, types.GenericAlias)
+        assert alias.__origin__ is np.dtype
+
+    @pytest.mark.parametrize("code", np.typecodes["All"])
+    def test_dtype_subclass(self, code: str) -> None:
+        cls = type(np.dtype(code))
+        alias = cls[Any]
+        assert isinstance(alias, types.GenericAlias)
+        assert alias.__origin__ is cls
+
+    @pytest.mark.parametrize("arg_len", range(4))
+    def test_subscript_tuple(self, arg_len: int) -> None:
+        arg_tup = (Any,) * arg_len
+        if arg_len == 1:
+            assert np.dtype[arg_tup]
+        else:
+            with pytest.raises(TypeError):
+                np.dtype[arg_tup]
+
+    def test_subscript_scalar(self) -> None:
+        assert np.dtype[Any]
+
+
+def test_result_type_integers_and_unitless_timedelta64():
+    # Regression test for gh-20077.  The following call of `result_type`
+    # would cause a seg. fault.
+    td = np.timedelta64(4)
+    result = np.result_type(0, td)
+    assert_dtype_equal(result, td.dtype)
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Requires python 3.8")
+def test_class_getitem_38() -> None:
+    match = "Type subscription requires python >= 3.9"
+    with pytest.raises(TypeError, match=match):
+        np.dtype[Any]

--- a/torch_np/tests/numpy_tests/core/test_dtype.py
+++ b/torch_np/tests/numpy_tests/core/test_dtype.py
@@ -1,23 +1,23 @@
 import sys
 import operator
 import pytest
-import ctypes
-import gc
 import types
 from typing import Any
 
 import numpy as np
-from numpy.core._rational_tests import rational
-from numpy.core._multiarray_tests import create_custom_field_dtype
 from numpy.testing import (
-    assert_, assert_equal, assert_array_equal, assert_raises, HAS_REFCOUNT,
-    IS_PYSTON, _OLD_PROMOTION)
+    assert_, assert_equal, assert_array_equal, assert_raises)
 from numpy.compat import pickle
+
+import torch_np as np
+from torch_np.testing import (
+    assert_, assert_equal, assert_array_equal, assert_raises)
+#from numpy.compat import pickle
+
+import pickle
 from itertools import permutations
 import random
 
-import hypothesis
-from hypothesis.extra import numpy as hynp
 
 
 
@@ -32,26 +32,11 @@ def assert_dtype_not_equal(a, b):
             "two different types hash to the same value !")
 
 class TestBuiltin:
-    @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
-                                   np.compat.unicode])
+    @pytest.mark.parametrize('t', [int, float, complex, np.int32])
     def test_run(self, t):
         """Only test hash runs at all."""
         dt = np.dtype(t)
         hash(dt)
-
-    @pytest.mark.parametrize('t', [int, float])
-    def test_dtype(self, t):
-        # Make sure equivalent byte order char hash the same (e.g. < and = on
-        # little endian)
-        dt = np.dtype(t)
-        dt2 = dt.newbyteorder("<")
-        dt3 = dt.newbyteorder(">")
-        if dt == dt2:
-            assert_(dt.byteorder != dt2.byteorder, "bogus test")
-            assert_dtype_equal(dt, dt2)
-        else:
-            assert_(dt.byteorder != dt3.byteorder, "bogus test")
-            assert_dtype_equal(dt, dt3)
 
     def test_equivalent_dtype_hashing(self):
         # Make sure equivalent dtypes with different type num hash equal
@@ -137,9 +122,8 @@ class TestBuiltin:
 
     @pytest.mark.parametrize(
         'value',
-        ['m8', 'M8', 'datetime64', 'timedelta64',
-         'i4, (2,3)f8, f4', 'a3, 3u8, (3,4)a10',
-         '>f', '<f', '=f', '|f',
+        [
+         'i4, f4'
         ])
     def test_dtype_bytes_str_equivalence(self, value):
         bytes_value = value.encode('ascii')
@@ -148,16 +132,6 @@ class TestBuiltin:
         assert_dtype_equal(from_bytes, from_str)
 
     def test_dtype_from_bytes(self):
-        # Empty bytes object
-        assert_raises(TypeError, np.dtype, b'')
-        # Byte order indicator, but no type
-        assert_raises(TypeError, np.dtype, b'|')
-
-        # Single character with ordinal < NPY_NTYPES returns
-        # type by index into _builtin_descrs
-        assert_dtype_equal(np.dtype(bytes([0])), np.dtype('bool'))
-        assert_dtype_equal(np.dtype(bytes([17])), np.dtype(object))
-
         # Single character where value is a valid type code
         assert_dtype_equal(np.dtype(b'f'), np.dtype('float32'))
 
@@ -165,521 +139,11 @@ class TestBuiltin:
         assert_raises(TypeError, np.dtype, b'\xff')
         assert_raises(TypeError, np.dtype, b's\xff')
 
-    def test_bad_param(self):
-        # Can't give a size that's too small
-        assert_raises(ValueError, np.dtype,
-                        {'names':['f0', 'f1'],
-                         'formats':['i4', 'i1'],
-                         'offsets':[0, 4],
-                         'itemsize':4})
-        # If alignment is enabled, the alignment (4) must divide the itemsize
-        assert_raises(ValueError, np.dtype,
-                        {'names':['f0', 'f1'],
-                         'formats':['i4', 'i1'],
-                         'offsets':[0, 4],
-                         'itemsize':9}, align=True)
-        # If alignment is enabled, the individual fields must be aligned
-        assert_raises(ValueError, np.dtype,
-                        {'names':['f0', 'f1'],
-                         'formats':['i1', 'f4'],
-                         'offsets':[0, 2]}, align=True)
-
-    def test_field_order_equality(self):
-        x = np.dtype({'names': ['A', 'B'],
-                      'formats': ['i4', 'f4'],
-                      'offsets': [0, 4]})
-        y = np.dtype({'names': ['B', 'A'],
-                      'formats': ['i4', 'f4'],
-                      'offsets': [4, 0]})
-        assert_equal(x == y, False)
-        # This is an safe cast (not equiv) due to the different names:
-        assert np.can_cast(x, y, casting="safe")
 
 
-class TestRecord:
-    def test_equivalent_record(self):
-        """Test whether equivalent record dtypes hash the same."""
-        a = np.dtype([('yo', int)])
-        b = np.dtype([('yo', int)])
-        assert_dtype_equal(a, b)
-
-    def test_different_names(self):
-        # In theory, they may hash the same (collision) ?
-        a = np.dtype([('yo', int)])
-        b = np.dtype([('ye', int)])
-        assert_dtype_not_equal(a, b)
-
-    def test_different_titles(self):
-        # In theory, they may hash the same (collision) ?
-        a = np.dtype({'names': ['r', 'b'],
-                      'formats': ['u1', 'u1'],
-                      'titles': ['Red pixel', 'Blue pixel']})
-        b = np.dtype({'names': ['r', 'b'],
-                      'formats': ['u1', 'u1'],
-                      'titles': ['RRed pixel', 'Blue pixel']})
-        assert_dtype_not_equal(a, b)
-
-    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
-    def test_refcount_dictionary_setting(self):
-        names = ["name1"]
-        formats = ["f8"]
-        titles = ["t1"]
-        offsets = [0]
-        d = dict(names=names, formats=formats, titles=titles, offsets=offsets)
-        refcounts = {k: sys.getrefcount(i) for k, i in d.items()}
-        np.dtype(d)
-        refcounts_new = {k: sys.getrefcount(i) for k, i in d.items()}
-        assert refcounts == refcounts_new
-
-    def test_mutate(self):
-        # Mutating a dtype should reset the cached hash value.
-        # NOTE: Mutating should be deprecated, but new API added to replace it.
-        a = np.dtype([('yo', int)])
-        b = np.dtype([('yo', int)])
-        c = np.dtype([('ye', int)])
-        assert_dtype_equal(a, b)
-        assert_dtype_not_equal(a, c)
-        a.names = ['ye']
-        assert_dtype_equal(a, c)
-        assert_dtype_not_equal(a, b)
-        state = b.__reduce__()[2]
-        a.__setstate__(state)
-        assert_dtype_equal(a, b)
-        assert_dtype_not_equal(a, c)
-
-    def test_mutate_error(self):
-        # NOTE: Mutating should be deprecated, but new API added to replace it.
-        a = np.dtype("i,i")
-
-        with pytest.raises(ValueError, match="must replace all names at once"):
-            a.names = ["f0"]
-
-        with pytest.raises(ValueError, match=".*and not string"):
-            a.names = ["f0", b"not a unicode name"]
-
-    def test_not_lists(self):
-        """Test if an appropriate exception is raised when passing bad values to
-        the dtype constructor.
-        """
-        assert_raises(TypeError, np.dtype,
-                      dict(names={'A', 'B'}, formats=['f8', 'i4']))
-        assert_raises(TypeError, np.dtype,
-                      dict(names=['A', 'B'], formats={'f8', 'i4'}))
-
-    def test_aligned_size(self):
-        # Check that structured dtypes get padded to an aligned size
-        dt = np.dtype('i4, i1', align=True)
-        assert_equal(dt.itemsize, 8)
-        dt = np.dtype([('f0', 'i4'), ('f1', 'i1')], align=True)
-        assert_equal(dt.itemsize, 8)
-        dt = np.dtype({'names':['f0', 'f1'],
-                       'formats':['i4', 'u1'],
-                       'offsets':[0, 4]}, align=True)
-        assert_equal(dt.itemsize, 8)
-        dt = np.dtype({'f0': ('i4', 0), 'f1':('u1', 4)}, align=True)
-        assert_equal(dt.itemsize, 8)
-        # Nesting should preserve that alignment
-        dt1 = np.dtype([('f0', 'i4'),
-                       ('f1', [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')]),
-                       ('f2', 'i1')], align=True)
-        assert_equal(dt1.itemsize, 20)
-        dt2 = np.dtype({'names':['f0', 'f1', 'f2'],
-                       'formats':['i4',
-                                  [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')],
-                                  'i1'],
-                       'offsets':[0, 4, 16]}, align=True)
-        assert_equal(dt2.itemsize, 20)
-        dt3 = np.dtype({'f0': ('i4', 0),
-                       'f1': ([('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')], 4),
-                       'f2': ('i1', 16)}, align=True)
-        assert_equal(dt3.itemsize, 20)
-        assert_equal(dt1, dt2)
-        assert_equal(dt2, dt3)
-        # Nesting should preserve packing
-        dt1 = np.dtype([('f0', 'i4'),
-                       ('f1', [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')]),
-                       ('f2', 'i1')], align=False)
-        assert_equal(dt1.itemsize, 11)
-        dt2 = np.dtype({'names':['f0', 'f1', 'f2'],
-                       'formats':['i4',
-                                  [('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')],
-                                  'i1'],
-                       'offsets':[0, 4, 10]}, align=False)
-        assert_equal(dt2.itemsize, 11)
-        dt3 = np.dtype({'f0': ('i4', 0),
-                       'f1': ([('f1', 'i1'), ('f2', 'i4'), ('f3', 'i1')], 4),
-                       'f2': ('i1', 10)}, align=False)
-        assert_equal(dt3.itemsize, 11)
-        assert_equal(dt1, dt2)
-        assert_equal(dt2, dt3)
-        # Array of subtype should preserve alignment
-        dt1 = np.dtype([('a', '|i1'),
-                        ('b', [('f0', '<i2'),
-                        ('f1', '<f4')], 2)], align=True)
-        assert_equal(dt1.descr, [('a', '|i1'), ('', '|V3'),
-                                 ('b', [('f0', '<i2'), ('', '|V2'),
-                                 ('f1', '<f4')], (2,))])
-
-    def test_union_struct(self):
-        # Should be able to create union dtypes
-        dt = np.dtype({'names':['f0', 'f1', 'f2'], 'formats':['<u4', '<u2', '<u2'],
-                        'offsets':[0, 0, 2]}, align=True)
-        assert_equal(dt.itemsize, 4)
-        a = np.array([3], dtype='<u4').view(dt)
-        a['f1'] = 10
-        a['f2'] = 36
-        assert_equal(a['f0'], 10 + 36*256*256)
-        # Should be able to specify fields out of order
-        dt = np.dtype({'names':['f0', 'f1', 'f2'], 'formats':['<u4', '<u2', '<u2'],
-                        'offsets':[4, 0, 2]}, align=True)
-        assert_equal(dt.itemsize, 8)
-        # field name should not matter: assignment is by position
-        dt2 = np.dtype({'names':['f2', 'f0', 'f1'],
-                        'formats':['<u4', '<u2', '<u2'],
-                        'offsets':[4, 0, 2]}, align=True)
-        vals = [(0, 1, 2), (3, 2**15-1, 4)]
-        vals2 = [(0, 1, 2), (3, 2**15-1, 4)]
-        a = np.array(vals, dt)
-        b = np.array(vals2, dt2)
-        assert_equal(a.astype(dt2), b)
-        assert_equal(b.astype(dt), a)
-        assert_equal(a.view(dt2), b)
-        assert_equal(b.view(dt), a)
-        # Should not be able to overlap objects with other types
-        assert_raises(TypeError, np.dtype,
-                {'names':['f0', 'f1'],
-                 'formats':['O', 'i1'],
-                 'offsets':[0, 2]})
-        assert_raises(TypeError, np.dtype,
-                {'names':['f0', 'f1'],
-                 'formats':['i4', 'O'],
-                 'offsets':[0, 3]})
-        assert_raises(TypeError, np.dtype,
-                {'names':['f0', 'f1'],
-                 'formats':[[('a', 'O')], 'i1'],
-                 'offsets':[0, 2]})
-        assert_raises(TypeError, np.dtype,
-                {'names':['f0', 'f1'],
-                 'formats':['i4', [('a', 'O')]],
-                 'offsets':[0, 3]})
-        # Out of order should still be ok, however
-        dt = np.dtype({'names':['f0', 'f1'],
-                       'formats':['i1', 'O'],
-                       'offsets':[np.dtype('intp').itemsize, 0]})
-
-    @pytest.mark.parametrize(["obj", "dtype", "expected"],
-        [([], ("(2)f4,"), np.empty((0, 2), dtype="f4")),
-         (3, "(3)f4,", [3, 3, 3]),
-         (np.float64(2), "(2)f4,", [2, 2]),
-         ([((0, 1), (1, 2)), ((2,),)], '(2,2)f4', None),
-         (["1", "2"], "(2)i,", None)])
-    def test_subarray_list(self, obj, dtype, expected):
-        dtype = np.dtype(dtype)
-        res = np.array(obj, dtype=dtype)
-
-        if expected is None:
-            # iterate the 1-d list to fill the array
-            expected = np.empty(len(obj), dtype=dtype)
-            for i in range(len(expected)):
-                expected[i] = obj[i]
-
-        assert_array_equal(res, expected)
-
-    def test_comma_datetime(self):
-        dt = np.dtype('M8[D],datetime64[Y],i8')
-        assert_equal(dt, np.dtype([('f0', 'M8[D]'),
-                                   ('f1', 'datetime64[Y]'),
-                                   ('f2', 'i8')]))
-
-    def test_from_dictproxy(self):
-        # Tests for PR #5920
-        dt = np.dtype({'names': ['a', 'b'], 'formats': ['i4', 'f4']})
-        assert_dtype_equal(dt, np.dtype(dt.fields))
-        dt2 = np.dtype((np.void, dt.fields))
-        assert_equal(dt2.fields, dt.fields)
-
-    def test_from_dict_with_zero_width_field(self):
-        # Regression test for #6430 / #2196
-        dt = np.dtype([('val1', np.float32, (0,)), ('val2', int)])
-        dt2 = np.dtype({'names': ['val1', 'val2'],
-                        'formats': [(np.float32, (0,)), int]})
-
-        assert_dtype_equal(dt, dt2)
-        assert_equal(dt.fields['val1'][0].itemsize, 0)
-        assert_equal(dt.itemsize, dt.fields['val2'][0].itemsize)
-
-    def test_bool_commastring(self):
-        d = np.dtype('?,?,?')  # raises?
-        assert_equal(len(d.names), 3)
-        for n in d.names:
-            assert_equal(d.fields[n][0], np.dtype('?'))
-
-    def test_nonint_offsets(self):
-        # gh-8059
-        def make_dtype(off):
-            return np.dtype({'names': ['A'], 'formats': ['i4'],
-                             'offsets': [off]})
-
-        assert_raises(TypeError, make_dtype, 'ASD')
-        assert_raises(OverflowError, make_dtype, 2**70)
-        assert_raises(TypeError, make_dtype, 2.3)
-        assert_raises(ValueError, make_dtype, -10)
-
-        # no errors here:
-        dt = make_dtype(np.uint32(0))
-        np.zeros(1, dtype=dt)[0].item()
-
-    def test_fields_by_index(self):
-        dt = np.dtype([('a', np.int8), ('b', np.float32, 3)])
-        assert_dtype_equal(dt[0], np.dtype(np.int8))
-        assert_dtype_equal(dt[1], np.dtype((np.float32, 3)))
-        assert_dtype_equal(dt[-1], dt[1])
-        assert_dtype_equal(dt[-2], dt[0])
-        assert_raises(IndexError, lambda: dt[-3])
-
-        assert_raises(TypeError, operator.getitem, dt, 3.0)
-
-        assert_equal(dt[1], dt[np.int8(1)])
-
-    @pytest.mark.parametrize('align_flag',[False, True])
-    def test_multifield_index(self, align_flag):
-        # indexing with a list produces subfields
-        # the align flag should be preserved
-        dt = np.dtype([
-            (('title', 'col1'), '<U20'), ('A', '<f8'), ('B', '<f8')
-        ], align=align_flag)
-
-        dt_sub = dt[['B', 'col1']]
-        assert_equal(
-            dt_sub,
-            np.dtype({
-                'names': ['B', 'col1'],
-                'formats': ['<f8', '<U20'],
-                'offsets': [88, 0],
-                'titles': [None, 'title'],
-                'itemsize': 96
-            })
-        )
-        assert_equal(dt_sub.isalignedstruct, align_flag)
-
-        dt_sub = dt[['B']]
-        assert_equal(
-            dt_sub,
-            np.dtype({
-                'names': ['B'],
-                'formats': ['<f8'],
-                'offsets': [88],
-                'itemsize': 96
-            })
-        )
-        assert_equal(dt_sub.isalignedstruct, align_flag)
-
-        dt_sub = dt[[]]
-        assert_equal(
-            dt_sub,
-            np.dtype({
-                'names': [],
-                'formats': [],
-                'offsets': [],
-                'itemsize': 96
-            })
-        )
-        assert_equal(dt_sub.isalignedstruct, align_flag)
-
-        assert_raises(TypeError, operator.getitem, dt, ())
-        assert_raises(TypeError, operator.getitem, dt, [1, 2, 3])
-        assert_raises(TypeError, operator.getitem, dt, ['col1', 2])
-        assert_raises(KeyError, operator.getitem, dt, ['fake'])
-        assert_raises(KeyError, operator.getitem, dt, ['title'])
-        assert_raises(ValueError, operator.getitem, dt, ['col1', 'col1'])
-
-    def test_partial_dict(self):
-        # 'names' is missing
-        assert_raises(ValueError, np.dtype,
-                {'formats': ['i4', 'i4'], 'f0': ('i4', 0), 'f1':('i4', 4)})
-
-    def test_fieldless_views(self):
-        a = np.zeros(2, dtype={'names':[], 'formats':[], 'offsets':[],
-                               'itemsize':8})
-        assert_raises(ValueError, a.view, np.dtype([]))
-
-        d = np.dtype((np.dtype([]), 10))
-        assert_equal(d.shape, (10,))
-        assert_equal(d.itemsize, 0)
-        assert_equal(d.base, np.dtype([]))
-
-        arr = np.fromiter((() for i in range(10)), [])
-        assert_equal(arr.dtype, np.dtype([]))
-        assert_raises(ValueError, np.frombuffer, b'', dtype=[])
-        assert_equal(np.frombuffer(b'', dtype=[], count=2),
-                     np.empty(2, dtype=[]))
-
-        assert_raises(ValueError, np.dtype, ([], 'f8'))
-        assert_raises(ValueError, np.zeros(1, dtype='i4').view, [])
-
-        assert_equal(np.zeros(2, dtype=[]) == np.zeros(2, dtype=[]),
-                     np.ones(2, dtype=bool))
-
-        assert_equal(np.zeros((1, 2), dtype=[]) == a,
-                     np.ones((1, 2), dtype=bool))
 
 
-class TestSubarray:
-    def test_single_subarray(self):
-        a = np.dtype((int, (2)))
-        b = np.dtype((int, (2,)))
-        assert_dtype_equal(a, b)
 
-        assert_equal(type(a.subdtype[1]), tuple)
-        assert_equal(type(b.subdtype[1]), tuple)
-
-    def test_equivalent_record(self):
-        """Test whether equivalent subarray dtypes hash the same."""
-        a = np.dtype((int, (2, 3)))
-        b = np.dtype((int, (2, 3)))
-        assert_dtype_equal(a, b)
-
-    def test_nonequivalent_record(self):
-        """Test whether different subarray dtypes hash differently."""
-        a = np.dtype((int, (2, 3)))
-        b = np.dtype((int, (3, 2)))
-        assert_dtype_not_equal(a, b)
-
-        a = np.dtype((int, (2, 3)))
-        b = np.dtype((int, (2, 2)))
-        assert_dtype_not_equal(a, b)
-
-        a = np.dtype((int, (1, 2, 3)))
-        b = np.dtype((int, (1, 2)))
-        assert_dtype_not_equal(a, b)
-
-    def test_shape_equal(self):
-        """Test some data types that are equal"""
-        assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', tuple())))
-        # FutureWarning during deprecation period; after it is passed this
-        # should instead check that "(1)f8" == "1f8" == ("f8", 1).
-        with pytest.warns(FutureWarning):
-            assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', 1)))
-        assert_dtype_equal(np.dtype((int, 2)), np.dtype((int, (2,))))
-        assert_dtype_equal(np.dtype(('<f4', (3, 2))), np.dtype(('<f4', (3, 2))))
-        d = ([('a', 'f4', (1, 2)), ('b', 'f8', (3, 1))], (3, 2))
-        assert_dtype_equal(np.dtype(d), np.dtype(d))
-
-    def test_shape_simple(self):
-        """Test some simple cases that shouldn't be equal"""
-        assert_dtype_not_equal(np.dtype('f8'), np.dtype(('f8', (1,))))
-        assert_dtype_not_equal(np.dtype(('f8', (1,))), np.dtype(('f8', (1, 1))))
-        assert_dtype_not_equal(np.dtype(('f4', (3, 2))), np.dtype(('f4', (2, 3))))
-
-    def test_shape_monster(self):
-        """Test some more complicated cases that shouldn't be equal"""
-        assert_dtype_not_equal(
-            np.dtype(([('a', 'f4', (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
-            np.dtype(([('a', 'f4', (1, 2)), ('b', 'f8', (1, 3))], (2, 2))))
-        assert_dtype_not_equal(
-            np.dtype(([('a', 'f4', (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
-            np.dtype(([('a', 'f4', (2, 1)), ('b', 'i8', (1, 3))], (2, 2))))
-        assert_dtype_not_equal(
-            np.dtype(([('a', 'f4', (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
-            np.dtype(([('e', 'f8', (1, 3)), ('d', 'f4', (2, 1))], (2, 2))))
-        assert_dtype_not_equal(
-            np.dtype(([('a', [('a', 'i4', 6)], (2, 1)), ('b', 'f8', (1, 3))], (2, 2))),
-            np.dtype(([('a', [('a', 'u4', 6)], (2, 1)), ('b', 'f8', (1, 3))], (2, 2))))
-
-    def test_shape_sequence(self):
-        # Any sequence of integers should work as shape, but the result
-        # should be a tuple (immutable) of base type integers.
-        a = np.array([1, 2, 3], dtype=np.int16)
-        l = [1, 2, 3]
-        # Array gets converted
-        dt = np.dtype([('a', 'f4', a)])
-        assert_(isinstance(dt['a'].shape, tuple))
-        assert_(isinstance(dt['a'].shape[0], int))
-        # List gets converted
-        dt = np.dtype([('a', 'f4', l)])
-        assert_(isinstance(dt['a'].shape, tuple))
-        #
-
-        class IntLike:
-            def __index__(self):
-                return 3
-
-            def __int__(self):
-                # (a PyNumber_Check fails without __int__)
-                return 3
-
-        dt = np.dtype([('a', 'f4', IntLike())])
-        assert_(isinstance(dt['a'].shape, tuple))
-        assert_(isinstance(dt['a'].shape[0], int))
-        dt = np.dtype([('a', 'f4', (IntLike(),))])
-        assert_(isinstance(dt['a'].shape, tuple))
-        assert_(isinstance(dt['a'].shape[0], int))
-
-    def test_shape_matches_ndim(self):
-        dt = np.dtype([('a', 'f4', ())])
-        assert_equal(dt['a'].shape, ())
-        assert_equal(dt['a'].ndim, 0)
-
-        dt = np.dtype([('a', 'f4')])
-        assert_equal(dt['a'].shape, ())
-        assert_equal(dt['a'].ndim, 0)
-
-        dt = np.dtype([('a', 'f4', 4)])
-        assert_equal(dt['a'].shape, (4,))
-        assert_equal(dt['a'].ndim, 1)
-
-        dt = np.dtype([('a', 'f4', (1, 2, 3))])
-        assert_equal(dt['a'].shape, (1, 2, 3))
-        assert_equal(dt['a'].ndim, 3)
-
-    def test_shape_invalid(self):
-        # Check that the shape is valid.
-        max_int = np.iinfo(np.intc).max
-        max_intp = np.iinfo(np.intp).max
-        # Too large values (the datatype is part of this)
-        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int // 4 + 1)])
-        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int + 1)])
-        assert_raises(ValueError, np.dtype, [('a', 'f4', (max_int, 2))])
-        # Takes a different code path (fails earlier:
-        assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp + 1)])
-        # Negative values
-        assert_raises(ValueError, np.dtype, [('a', 'f4', -1)])
-        assert_raises(ValueError, np.dtype, [('a', 'f4', (-1, -1))])
-
-    def test_alignment(self):
-        #Check that subarrays are aligned
-        t1 = np.dtype('(1,)i4', align=True)
-        t2 = np.dtype('2i4', align=True)
-        assert_equal(t1.alignment, t2.alignment)
-
-    def test_aligned_empty(self):
-        # Mainly regression test for gh-19696: construction failed completely
-        dt = np.dtype([], align=True)
-        assert dt == np.dtype([])
-        dt = np.dtype({"names": [], "formats": [], "itemsize": 0}, align=True)
-        assert dt == np.dtype([])
-
-    def test_subarray_base_item(self):
-        arr = np.ones(3, dtype=[("f", "i", 3)])
-        # Extracting the field "absorbs" the subarray into a view:
-        assert arr["f"].base is arr
-        # Extract the structured item, and then check the tuple component:
-        item = arr.item(0)
-        assert type(item) is tuple and len(item) == 1
-        assert item[0].base is arr
-
-    def test_subarray_cast_copies(self):
-        # Older versions of NumPy did NOT copy, but they got the ownership
-        # wrong (not actually knowing the correct base!).  Versions since 1.21
-        # (I think) crashed fairly reliable.  This defines the correct behavior
-        # as a copy.  Keeping the ownership would be possible (but harder)
-        arr = np.ones(3, dtype=[("f", "i", 3)])
-        cast = arr.astype(object)
-        for fields in cast:
-            assert type(fields) == tuple and len(fields) == 1
-            subarr = fields[0]
-            assert subarr.base is None
-            assert subarr.flags.owndata
 
 
 def iter_struct_object_dtypes():
@@ -719,357 +183,9 @@ def iter_struct_object_dtypes():
     yield pytest.param(dt, p, 12, obj, id="<structured subarray 2>")
 
 
-@pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
-class TestStructuredObjectRefcounting:
-    """These tests cover various uses of complicated structured types which
-    include objects and thus require reference counting.
-    """
-    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
-                             iter_struct_object_dtypes())
-    @pytest.mark.parametrize(["creation_func", "creation_obj"], [
-        pytest.param(np.empty, None,
-             # None is probably used for too many things
-             marks=pytest.mark.skip("unreliable due to python's behaviour")),
-        (np.ones, 1),
-        (np.zeros, 0)])
-    def test_structured_object_create_delete(self, dt, pat, count, singleton,
-                                             creation_func, creation_obj):
-        """Structured object reference counting in creation and deletion"""
-        # The test assumes that 0, 1, and None are singletons.
-        gc.collect()
-        before = sys.getrefcount(creation_obj)
-        arr = creation_func(3, dt)
-
-        now = sys.getrefcount(creation_obj)
-        assert now - before == count * 3
-        del arr
-        now = sys.getrefcount(creation_obj)
-        assert now == before
-
-    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
-                             iter_struct_object_dtypes())
-    def test_structured_object_item_setting(self, dt, pat, count, singleton):
-        """Structured object reference counting for simple item setting"""
-        one = 1
-
-        gc.collect()
-        before = sys.getrefcount(singleton)
-        arr = np.array([pat] * 3, dt)
-        assert sys.getrefcount(singleton) - before == count * 3
-        # Fill with `1` and check that it was replaced correctly:
-        before2 = sys.getrefcount(one)
-        arr[...] = one
-        after2 = sys.getrefcount(one)
-        assert after2 - before2 == count * 3
-        del arr
-        gc.collect()
-        assert sys.getrefcount(one) == before2
-        assert sys.getrefcount(singleton) == before
-
-    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
-                             iter_struct_object_dtypes())
-    @pytest.mark.parametrize(
-        ['shape', 'index', 'items_changed'],
-        [((3,), ([0, 2],), 2),
-         ((3, 2), ([0, 2], slice(None)), 4),
-         ((3, 2), ([0, 2], [1]), 2),
-         ((3,), ([True, False, True]), 2)])
-    def test_structured_object_indexing(self, shape, index, items_changed,
-                                        dt, pat, count, singleton):
-        """Structured object reference counting for advanced indexing."""
-        # Use two small negative values (should be singletons, but less likely
-        # to run into race-conditions).  This failed in some threaded envs
-        # When using 0 and 1.  If it fails again, should remove all explicit
-        # checks, and rely on `pytest-leaks` reference count checker only.
-        val0 = -4
-        val1 = -5
-
-        arr = np.full(shape, val0, dt)
-
-        gc.collect()
-        before_val0 = sys.getrefcount(val0)
-        before_val1 = sys.getrefcount(val1)
-        # Test item getting:
-        part = arr[index]
-        after_val0 = sys.getrefcount(val0)
-        assert after_val0 - before_val0 == count * items_changed
-        del part
-        # Test item setting:
-        arr[index] = val1
-        gc.collect()
-        after_val0 = sys.getrefcount(val0)
-        after_val1 = sys.getrefcount(val1)
-        assert before_val0 - after_val0 == count * items_changed
-        assert after_val1 - before_val1 == count * items_changed
-
-    @pytest.mark.parametrize(['dt', 'pat', 'count', 'singleton'],
-                             iter_struct_object_dtypes())
-    def test_structured_object_take_and_repeat(self, dt, pat, count, singleton):
-        """Structured object reference counting for specialized functions.
-        The older functions such as take and repeat use different code paths
-        then item setting (when writing this).
-        """
-        indices = [0, 1]
-
-        arr = np.array([pat] * 3, dt)
-        gc.collect()
-        before = sys.getrefcount(singleton)
-        res = arr.take(indices)
-        after = sys.getrefcount(singleton)
-        assert after - before == count * 2
-        new = res.repeat(10)
-        gc.collect()
-        after_repeat = sys.getrefcount(singleton)
-        assert after_repeat - after == count * 2 * 10
 
 
-class TestStructuredDtypeSparseFields:
-    """Tests subarray fields which contain sparse dtypes so that
-    not all memory is used by the dtype work. Such dtype's should
-    leave the underlying memory unchanged.
-    """
-    dtype = np.dtype([('a', {'names':['aa', 'ab'], 'formats':['f', 'f'],
-                             'offsets':[0, 4]}, (2, 3))])
-    sparse_dtype = np.dtype([('a', {'names':['ab'], 'formats':['f'],
-                                    'offsets':[4]}, (2, 3))])
 
-    def test_sparse_field_assignment(self):
-        arr = np.zeros(3, self.dtype)
-        sparse_arr = arr.view(self.sparse_dtype)
-
-        sparse_arr[...] = np.finfo(np.float32).max
-        # dtype is reduced when accessing the field, so shape is (3, 2, 3):
-        assert_array_equal(arr["a"]["aa"], np.zeros((3, 2, 3)))
-
-    def test_sparse_field_assignment_fancy(self):
-        # Fancy assignment goes to the copyswap function for complex types:
-        arr = np.zeros(3, self.dtype)
-        sparse_arr = arr.view(self.sparse_dtype)
-
-        sparse_arr[[0, 1, 2]] = np.finfo(np.float32).max
-        # dtype is reduced when accessing the field, so shape is (3, 2, 3):
-        assert_array_equal(arr["a"]["aa"], np.zeros((3, 2, 3)))
-
-
-class TestMonsterType:
-    """Test deeply nested subtypes."""
-
-    def test1(self):
-        simple1 = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
-            'titles': ['Red pixel', 'Blue pixel']})
-        a = np.dtype([('yo', int), ('ye', simple1),
-            ('yi', np.dtype((int, (3, 2))))])
-        b = np.dtype([('yo', int), ('ye', simple1),
-            ('yi', np.dtype((int, (3, 2))))])
-        assert_dtype_equal(a, b)
-
-        c = np.dtype([('yo', int), ('ye', simple1),
-            ('yi', np.dtype((a, (3, 2))))])
-        d = np.dtype([('yo', int), ('ye', simple1),
-            ('yi', np.dtype((a, (3, 2))))])
-        assert_dtype_equal(c, d)
-
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    def test_list_recursion(self):
-        l = list()
-        l.append(('f', l))
-        with pytest.raises(RecursionError):
-            np.dtype(l)
-
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    def test_tuple_recursion(self):
-        d = np.int32
-        for i in range(100000):
-            d = (d, (1,))
-        with pytest.raises(RecursionError):
-            np.dtype(d)
-
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    def test_dict_recursion(self):
-        d = dict(names=['self'], formats=[None], offsets=[0])
-        d['formats'][0] = d
-        with pytest.raises(RecursionError):
-            np.dtype(d)
-
-
-class TestMetadata:
-    def test_no_metadata(self):
-        d = np.dtype(int)
-        assert_(d.metadata is None)
-
-    def test_metadata_takes_dict(self):
-        d = np.dtype(int, metadata={'datum': 1})
-        assert_(d.metadata == {'datum': 1})
-
-    def test_metadata_rejects_nondict(self):
-        assert_raises(TypeError, np.dtype, int, metadata='datum')
-        assert_raises(TypeError, np.dtype, int, metadata=1)
-        assert_raises(TypeError, np.dtype, int, metadata=None)
-
-    def test_nested_metadata(self):
-        d = np.dtype([('a', np.dtype(int, metadata={'datum': 1}))])
-        assert_(d['a'].metadata == {'datum': 1})
-
-    def test_base_metadata_copied(self):
-        d = np.dtype((np.void, np.dtype('i4,i4', metadata={'datum': 1})))
-        assert_(d.metadata == {'datum': 1})
-
-class TestString:
-    def test_complex_dtype_str(self):
-        dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
-                                ('rtile', '>f4', (64, 36))], (3,)),
-                       ('bottom', [('bleft', ('>f4', (8, 64)), (1,)),
-                                   ('bright', '>f4', (8, 36))])])
-        assert_equal(str(dt),
-                     "[('top', [('tiles', ('>f4', (64, 64)), (1,)), "
-                     "('rtile', '>f4', (64, 36))], (3,)), "
-                     "('bottom', [('bleft', ('>f4', (8, 64)), (1,)), "
-                     "('bright', '>f4', (8, 36))])]")
-
-        # If the sticky aligned flag is set to True, it makes the
-        # str() function use a dict representation with an 'aligned' flag
-        dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
-                                ('rtile', '>f4', (64, 36))],
-                                (3,)),
-                       ('bottom', [('bleft', ('>f4', (8, 64)), (1,)),
-                                   ('bright', '>f4', (8, 36))])],
-                       align=True)
-        assert_equal(str(dt),
-                    "{'names': ['top', 'bottom'],"
-                    " 'formats': [([('tiles', ('>f4', (64, 64)), (1,)), "
-                                   "('rtile', '>f4', (64, 36))], (3,)), "
-                                  "[('bleft', ('>f4', (8, 64)), (1,)), "
-                                   "('bright', '>f4', (8, 36))]],"
-                    " 'offsets': [0, 76800],"
-                    " 'itemsize': 80000,"
-                    " 'aligned': True}")
-        with np.printoptions(legacy='1.21'):
-            assert_equal(str(dt),
-                        "{'names':['top','bottom'], "
-                         "'formats':[([('tiles', ('>f4', (64, 64)), (1,)), "
-                                      "('rtile', '>f4', (64, 36))], (3,)),"
-                                     "[('bleft', ('>f4', (8, 64)), (1,)), "
-                                      "('bright', '>f4', (8, 36))]], "
-                         "'offsets':[0,76800], "
-                         "'itemsize':80000, "
-                         "'aligned':True}")
-        assert_equal(np.dtype(eval(str(dt))), dt)
-
-        dt = np.dtype({'names': ['r', 'g', 'b'], 'formats': ['u1', 'u1', 'u1'],
-                        'offsets': [0, 1, 2],
-                        'titles': ['Red pixel', 'Green pixel', 'Blue pixel']})
-        assert_equal(str(dt),
-                    "[(('Red pixel', 'r'), 'u1'), "
-                    "(('Green pixel', 'g'), 'u1'), "
-                    "(('Blue pixel', 'b'), 'u1')]")
-
-        dt = np.dtype({'names': ['rgba', 'r', 'g', 'b'],
-                       'formats': ['<u4', 'u1', 'u1', 'u1'],
-                       'offsets': [0, 0, 1, 2],
-                       'titles': ['Color', 'Red pixel',
-                                  'Green pixel', 'Blue pixel']})
-        assert_equal(str(dt),
-                    "{'names': ['rgba', 'r', 'g', 'b'],"
-                    " 'formats': ['<u4', 'u1', 'u1', 'u1'],"
-                    " 'offsets': [0, 0, 1, 2],"
-                    " 'titles': ['Color', 'Red pixel', "
-                               "'Green pixel', 'Blue pixel'],"
-                    " 'itemsize': 4}")
-
-        dt = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
-                        'offsets': [0, 2],
-                        'titles': ['Red pixel', 'Blue pixel']})
-        assert_equal(str(dt),
-                    "{'names': ['r', 'b'],"
-                    " 'formats': ['u1', 'u1'],"
-                    " 'offsets': [0, 2],"
-                    " 'titles': ['Red pixel', 'Blue pixel'],"
-                    " 'itemsize': 3}")
-
-        dt = np.dtype([('a', '<m8[D]'), ('b', '<M8[us]')])
-        assert_equal(str(dt),
-                    "[('a', '<m8[D]'), ('b', '<M8[us]')]")
-
-    def test_repr_structured(self):
-        dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
-                                ('rtile', '>f4', (64, 36))], (3,)),
-                       ('bottom', [('bleft', ('>f4', (8, 64)), (1,)),
-                                   ('bright', '>f4', (8, 36))])])
-        assert_equal(repr(dt),
-                     "dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)), "
-                     "('rtile', '>f4', (64, 36))], (3,)), "
-                     "('bottom', [('bleft', ('>f4', (8, 64)), (1,)), "
-                     "('bright', '>f4', (8, 36))])])")
-
-        dt = np.dtype({'names': ['r', 'g', 'b'], 'formats': ['u1', 'u1', 'u1'],
-                        'offsets': [0, 1, 2],
-                        'titles': ['Red pixel', 'Green pixel', 'Blue pixel']},
-                        align=True)
-        assert_equal(repr(dt),
-                    "dtype([(('Red pixel', 'r'), 'u1'), "
-                    "(('Green pixel', 'g'), 'u1'), "
-                    "(('Blue pixel', 'b'), 'u1')], align=True)")
-
-    def test_repr_structured_not_packed(self):
-        dt = np.dtype({'names': ['rgba', 'r', 'g', 'b'],
-                       'formats': ['<u4', 'u1', 'u1', 'u1'],
-                       'offsets': [0, 0, 1, 2],
-                       'titles': ['Color', 'Red pixel',
-                                  'Green pixel', 'Blue pixel']}, align=True)
-        assert_equal(repr(dt),
-                    "dtype({'names': ['rgba', 'r', 'g', 'b'],"
-                    " 'formats': ['<u4', 'u1', 'u1', 'u1'],"
-                    " 'offsets': [0, 0, 1, 2],"
-                    " 'titles': ['Color', 'Red pixel', "
-                                "'Green pixel', 'Blue pixel'],"
-                    " 'itemsize': 4}, align=True)")
-
-        dt = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
-                        'offsets': [0, 2],
-                        'titles': ['Red pixel', 'Blue pixel'],
-                        'itemsize': 4})
-        assert_equal(repr(dt),
-                    "dtype({'names': ['r', 'b'], "
-                    "'formats': ['u1', 'u1'], "
-                    "'offsets': [0, 2], "
-                    "'titles': ['Red pixel', 'Blue pixel'], "
-                    "'itemsize': 4})")
-
-    def test_repr_structured_datetime(self):
-        dt = np.dtype([('a', '<M8[D]'), ('b', '<m8[us]')])
-        assert_equal(repr(dt),
-                    "dtype([('a', '<M8[D]'), ('b', '<m8[us]')])")
-
-    def test_repr_str_subarray(self):
-        dt = np.dtype(('<i2', (1,)))
-        assert_equal(repr(dt), "dtype(('<i2', (1,)))")
-        assert_equal(str(dt), "('<i2', (1,))")
-
-    def test_base_dtype_with_object_type(self):
-        # Issue gh-2798, should not error.
-        np.array(['a'], dtype="O").astype(("O", [("name", "O")]))
-
-    def test_empty_string_to_object(self):
-        # Pull request #4722
-        np.array(["", ""]).astype(object)
-
-    def test_void_subclass_unsized(self):
-        dt = np.dtype(np.record)
-        assert_equal(repr(dt), "dtype('V')")
-        assert_equal(str(dt), '|V0')
-        assert_equal(dt.name, 'record')
-
-    def test_void_subclass_sized(self):
-        dt = np.dtype((np.record, 2))
-        assert_equal(repr(dt), "dtype('V2')")
-        assert_equal(str(dt), '|V2')
-        assert_equal(dt.name, 'record16')
-
-    def test_void_subclass_fields(self):
-        dt = np.dtype((np.record, [('a', '<u2')]))
-        assert_equal(repr(dt), "dtype((numpy.record, [('a', '<u2')]))")
-        assert_equal(str(dt), "(numpy.record, [('a', '<u2')])")
-        assert_equal(dt.name, 'record16')
 
 
 class TestDtypeAttributeDeletion:
@@ -1090,155 +206,7 @@ class TestDtypeAttributeDeletion:
             assert_raises(AttributeError, delattr, dt, s)
 
 
-class TestDtypeAttributes:
-    def test_descr_has_trailing_void(self):
-        # see gh-6359
-        dtype = np.dtype({
-            'names': ['A', 'B'],
-            'formats': ['f4', 'f4'],
-            'offsets': [0, 8],
-            'itemsize': 16})
-        new_dtype = np.dtype(dtype.descr)
-        assert_equal(new_dtype.itemsize, 16)
 
-    def test_name_dtype_subclass(self):
-        # Ticket #4357
-        class user_def_subcls(np.void):
-            pass
-        assert_equal(np.dtype(user_def_subcls).name, 'user_def_subcls')
-
-    def test_zero_stride(self):
-        arr = np.ones(1, dtype="i8")
-        arr = np.broadcast_to(arr, 10)
-        assert arr.strides == (0,)
-        with pytest.raises(ValueError):
-            arr.dtype = "i1"
-
-class TestDTypeMakeCanonical:
-    def check_canonical(self, dtype, canonical):
-        """
-        Check most properties relevant to "canonical" versions of a dtype,
-        which is mainly native byte order for datatypes supporting this.
-
-        The main work is checking structured dtypes with fields, where we
-        reproduce most the actual logic used in the C-code.
-        """
-        assert type(dtype) is type(canonical)
-
-        # a canonical DType should always have equivalent casting (both ways)
-        assert np.can_cast(dtype, canonical, casting="equiv")
-        assert np.can_cast(canonical, dtype, casting="equiv")
-        # a canonical dtype (and its fields) is always native (checks fields):
-        assert canonical.isnative
-
-        # Check that canonical of canonical is the same (no casting):
-        assert np.result_type(canonical) == canonical
-
-        if not dtype.names:
-            # The flags currently never change for unstructured dtypes
-            assert dtype.flags == canonical.flags
-            return
-
-        # Must have all the needs API flag set:
-        assert dtype.flags & 0b10000
-
-        # Check that the fields are identical (including titles):
-        assert dtype.fields.keys() == canonical.fields.keys()
-
-        def aligned_offset(offset, alignment):
-            # round up offset:
-            return - (-offset // alignment) * alignment
-
-        totalsize = 0
-        max_alignment = 1
-        for name in dtype.names:
-            # each field is also canonical:
-            new_field_descr = canonical.fields[name][0]
-            self.check_canonical(dtype.fields[name][0], new_field_descr)
-
-            # Must have the "inherited" object related flags:
-            expected = 0b11011 & new_field_descr.flags
-            assert (canonical.flags & expected) == expected
-
-            if canonical.isalignedstruct:
-                totalsize = aligned_offset(totalsize, new_field_descr.alignment)
-                max_alignment = max(new_field_descr.alignment, max_alignment)
-
-            assert canonical.fields[name][1] == totalsize
-            # if a title exists, they must match (otherwise empty tuple):
-            assert dtype.fields[name][2:] == canonical.fields[name][2:]
-
-            totalsize += new_field_descr.itemsize
-
-        if canonical.isalignedstruct:
-            totalsize = aligned_offset(totalsize, max_alignment)
-        assert canonical.itemsize == totalsize
-        assert canonical.alignment == max_alignment
-
-    def test_simple(self):
-        dt = np.dtype(">i4")
-        assert np.result_type(dt).isnative
-        assert np.result_type(dt).num == dt.num
-
-        # dtype with empty space:
-        struct_dt = np.dtype(">i4,<i1,i8,V3")[["f0", "f2"]]
-        canonical = np.result_type(struct_dt)
-        assert canonical.itemsize == 4+8
-        assert canonical.isnative
-
-        # aligned struct dtype with empty space:
-        struct_dt = np.dtype(">i1,<i4,i8,V3", align=True)[["f0", "f2"]]
-        canonical = np.result_type(struct_dt)
-        assert canonical.isalignedstruct
-        assert canonical.itemsize == np.dtype("i8").alignment + 8
-        assert canonical.isnative
-
-    def test_object_flag_not_inherited(self):
-        # The following dtype still indicates "object", because its included
-        # in the unaccessible space (maybe this could change at some point):
-        arr = np.ones(3, "i,O,i")[["f0", "f2"]]
-        assert arr.dtype.hasobject
-        canonical_dt = np.result_type(arr.dtype)
-        assert not canonical_dt.hasobject
-
-    @pytest.mark.slow
-    @hypothesis.given(dtype=hynp.nested_dtypes())
-    def test_make_canonical_hypothesis(self, dtype):
-        canonical = np.result_type(dtype)
-        self.check_canonical(dtype, canonical)
-        # result_type with two arguments should always give identical results:
-        two_arg_result = np.result_type(dtype, dtype)
-        assert np.can_cast(two_arg_result, canonical, casting="no")
-
-    @pytest.mark.slow
-    @hypothesis.given(
-            dtype=hypothesis.extra.numpy.array_dtypes(
-                subtype_strategy=hypothesis.extra.numpy.array_dtypes(),
-                min_size=5, max_size=10, allow_subarrays=True))
-    def test_structured(self, dtype):
-        # Pick 4 of the fields at random.  This will leave empty space in the
-        # dtype (since we do not canonicalize it here).
-        field_subset = random.sample(dtype.names, k=4)
-        dtype_with_empty_space = dtype[field_subset]
-        assert dtype_with_empty_space.itemsize == dtype.itemsize
-        canonicalized = np.result_type(dtype_with_empty_space)
-        self.check_canonical(dtype_with_empty_space, canonicalized)
-        # promotion with two arguments should always give identical results:
-        two_arg_result = np.promote_types(
-                dtype_with_empty_space, dtype_with_empty_space)
-        assert np.can_cast(two_arg_result, canonicalized, casting="no")
-
-        # Ensure that we also check aligned struct (check the opposite, in
-        # case hypothesis grows support for `align`.  Then repeat the test:
-        dtype_aligned = np.dtype(dtype.descr, align=not dtype.isalignedstruct)
-        dtype_with_empty_space = dtype_aligned[field_subset]
-        assert dtype_with_empty_space.itemsize == dtype_aligned.itemsize
-        canonicalized = np.result_type(dtype_with_empty_space)
-        self.check_canonical(dtype_with_empty_space, canonicalized)
-        # promotion with two arguments should always give identical results:
-        two_arg_result = np.promote_types(
-            dtype_with_empty_space, dtype_with_empty_space)
-        assert np.can_cast(two_arg_result, canonicalized, casting="no")
 
 
 class TestPickling:
@@ -1261,54 +229,14 @@ class TestPickling:
             assert_equal(x, y)
             assert_equal(x[0], y[0])
 
-    @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
-                                   np.compat.unicode, bool])
+    @pytest.mark.parametrize('t', [int, float, complex, np.int32, bool])
     def test_builtin(self, t):
         self.check_pickling(np.dtype(t))
 
-    def test_structured(self):
-        dt = np.dtype(([('a', '>f4', (2, 1)), ('b', '<f8', (1, 3))], (2, 2)))
-        self.check_pickling(dt)
-
-    def test_structured_aligned(self):
-        dt = np.dtype('i4, i1', align=True)
-        self.check_pickling(dt)
-
-    def test_structured_unaligned(self):
-        dt = np.dtype('i4, i1', align=False)
-        self.check_pickling(dt)
-
-    def test_structured_padded(self):
-        dt = np.dtype({
-            'names': ['A', 'B'],
-            'formats': ['f4', 'f4'],
-            'offsets': [0, 8],
-            'itemsize': 16})
-        self.check_pickling(dt)
-
-    def test_structured_titles(self):
-        dt = np.dtype({'names': ['r', 'b'],
-                       'formats': ['u1', 'u1'],
-                       'titles': ['Red pixel', 'Blue pixel']})
-        self.check_pickling(dt)
-
-    @pytest.mark.parametrize('base', ['m8', 'M8'])
-    @pytest.mark.parametrize('unit', ['', 'Y', 'M', 'W', 'D', 'h', 'm', 's',
-                                      'ms', 'us', 'ns', 'ps', 'fs', 'as'])
-    def test_datetime(self, base, unit):
-        dt = np.dtype('%s[%s]' % (base, unit) if unit else base)
-        self.check_pickling(dt)
-        if unit:
-            dt = np.dtype('%s[7%s]' % (base, unit))
-            self.check_pickling(dt)
-
-    def test_metadata(self):
-        dt = np.dtype(int, metadata={'datum': 1})
-        self.check_pickling(dt)
 
     @pytest.mark.parametrize("DType",
         [type(np.dtype(t)) for t in np.typecodes['All']] +
-        [np.dtype(rational), np.dtype])
+        [np.dtype])
     def test_pickle_types(self, DType):
         # Check that DTypes (the classes/types) roundtrip when pickling
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1320,7 +248,7 @@ class TestPromotion:
     """Test cases related to more complex DType promotions.  Further promotion
     tests are defined in `test_numeric.py`
     """
-    @np._no_nep50_warning()
+###    @np._no_nep50_warning()
     @pytest.mark.parametrize(["other", "expected", "expected_weak"],
             [(2**16-1, np.complex64, None),
              (2**32-1, np.complex128, np.complex64),
@@ -1363,10 +291,8 @@ class TestPromotion:
                   (np.float16, np.complex64),
                   (np.float32, np.complex64),
                   (np.float64, np.complex128),
-                  (np.longdouble, np.clongdouble),
                   (np.complex64, np.complex64),
                   (np.complex128, np.complex128),
-                  (np.clongdouble, np.clongdouble),
                   ])
     def test_complex_scalar_value_based(self, other, expected):
         # This would change if we modify the value based promotion
@@ -1378,14 +304,6 @@ class TestPromotion:
         res = np.minimum(np.ones(3, dtype=other), complex_scalar).dtype
         assert res == expected
 
-    def test_complex_pyscalar_promote_rational(self):
-        with pytest.raises(TypeError,
-                match=r".* no common DType exists for the given inputs"):
-            np.result_type(1j, rational)
-
-        with pytest.raises(TypeError,
-                match=r".* no common DType exists for the given inputs"):
-            np.result_type(1j, rational(1, 2))
 
     @pytest.mark.parametrize("val", [2, 2**32, 2**63, 2**64, 2*100])
     def test_python_integer_promotion(self, val):
@@ -1397,25 +315,6 @@ class TestPromotion:
         # For completeness sake, also check with a NumPy scalar as second arg:
         assert np.result_type(val, np.int8(0)) == expected_dtype
 
-    @pytest.mark.parametrize(["other", "expected"],
-            [(1, rational), (1., np.float64)])
-    @np._no_nep50_warning()
-    def test_float_int_pyscalar_promote_rational(
-            self, weak_promotion, other, expected):
-        # Note that rationals are a bit akward as they promote with float64
-        # or default ints, but not float16 or uint8/int8 (which looks
-        # inconsistent here).  The new promotion fixes this (partially?)
-        if not weak_promotion and type(other) == float:
-            # The float version, checks float16 in the legacy path, which fails
-            # the integer version seems to check int8 (also), so it can
-            # pass.
-            with pytest.raises(TypeError,
-                    match=r".* do not have a common DType"):
-                np.result_type(other, rational)
-        else:
-            assert np.result_type(other, rational) == expected
-
-        assert np.result_type(other, rational(1, 2)) == expected
 
     @pytest.mark.parametrize(["dtypes", "expected"], [
              # These promotions are not associative/commutative:
@@ -1440,37 +339,18 @@ class TestPromotion:
             assert np.result_type(*perm) == expected
 
 
-def test_rational_dtype():
-    # test for bug gh-5719
-    a = np.array([1111], dtype=rational).astype
-    assert_raises(OverflowError, a, 'int8')
-
-    # test that dtype detection finds user-defined types
-    x = rational(1)
-    assert_equal(np.array([x,x]).dtype, np.dtype(rational))
-
 
 def test_dtypes_are_true():
     # test for gh-6294
     assert bool(np.dtype('f8'))
     assert bool(np.dtype('i8'))
-    assert bool(np.dtype([('a', 'i8'), ('b', 'f4')]))
 
 
-def test_invalid_dtype_string():
-    # test for gh-10440
-    assert_raises(TypeError, np.dtype, 'f8,i8,[f8,i8]')
-    assert_raises(TypeError, np.dtype, 'Fl\xfcgel')
 
 
 def test_keyword_argument():
     # test for https://github.com/numpy/numpy/pull/16574#issuecomment-642660971
     assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
-
-
-def test_ulong_dtype():
-    # test for gh-21063
-    assert np.dtype("ulong") == np.dtype(np.uint)
 
 
 class TestFromDTypeAttribute:
@@ -1481,7 +361,6 @@ class TestFromDTypeAttribute:
         assert np.dtype(dt) == np.float64
         assert np.dtype(dt()) == np.float64
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
     def test_recursion(self):
         class dt:
             pass
@@ -1495,32 +374,9 @@ class TestFromDTypeAttribute:
         with pytest.raises(RecursionError):
             np.dtype(dt_instance)
 
-    def test_void_subtype(self):
-        class dt(np.void):
-            # This code path is fully untested before, so it is unclear
-            # what this should be useful for. Note that if np.void is used
-            # numpy will think we are deallocating a base type [1.17, 2019-02].
-            dtype = np.dtype("f,f")
-
-        np.dtype(dt)
-        np.dtype(dt(1))
-
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    def test_void_subtype_recursion(self):
-        class vdt(np.void):
-            pass
-
-        vdt.dtype = vdt
-
-        with pytest.raises(RecursionError):
-            np.dtype(vdt)
-
-        with pytest.raises(RecursionError):
-            np.dtype(vdt(1))
-
 
 class TestDTypeClasses:
-    @pytest.mark.parametrize("dtype", list(np.typecodes['All']) + [rational])
+    @pytest.mark.parametrize("dtype", list(np.typecodes['All']))
     def test_basic_dtypes_subclass_properties(self, dtype):
         # Note: Except for the isinstance and type checks, these attributes
         #       are considered currently private and may change.
@@ -1551,238 +407,6 @@ class TestDTypeClasses:
         assert type(np.dtype).__module__ == "numpy"
         assert np.dtype._abstract
 
-
-class TestFromCTypes:
-
-    @staticmethod
-    def check(ctype, dtype):
-        dtype = np.dtype(dtype)
-        assert_equal(np.dtype(ctype), dtype)
-        assert_equal(np.dtype(ctype()), dtype)
-
-    def test_array(self):
-        c8 = ctypes.c_uint8
-        self.check(     3 * c8,  (np.uint8, (3,)))
-        self.check(     1 * c8,  (np.uint8, (1,)))
-        self.check(     0 * c8,  (np.uint8, (0,)))
-        self.check(1 * (3 * c8), ((np.uint8, (3,)), (1,)))
-        self.check(3 * (1 * c8), ((np.uint8, (1,)), (3,)))
-
-    def test_padded_structure(self):
-        class PaddedStruct(ctypes.Structure):
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16)
-            ]
-        expected = np.dtype([
-            ('a', np.uint8),
-            ('b', np.uint16)
-        ], align=True)
-        self.check(PaddedStruct, expected)
-
-    def test_bit_fields(self):
-        class BitfieldStruct(ctypes.Structure):
-            _fields_ = [
-                ('a', ctypes.c_uint8, 7),
-                ('b', ctypes.c_uint8, 1)
-            ]
-        assert_raises(TypeError, np.dtype, BitfieldStruct)
-        assert_raises(TypeError, np.dtype, BitfieldStruct())
-
-    def test_pointer(self):
-        p_uint8 = ctypes.POINTER(ctypes.c_uint8)
-        assert_raises(TypeError, np.dtype, p_uint8)
-
-    def test_void_pointer(self):
-        self.check(ctypes.c_void_p, np.uintp)
-
-    def test_union(self):
-        class Union(ctypes.Union):
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16),
-            ]
-        expected = np.dtype(dict(
-            names=['a', 'b'],
-            formats=[np.uint8, np.uint16],
-            offsets=[0, 0],
-            itemsize=2
-        ))
-        self.check(Union, expected)
-
-    def test_union_with_struct_packed(self):
-        class Struct(ctypes.Structure):
-            _pack_ = 1
-            _fields_ = [
-                ('one', ctypes.c_uint8),
-                ('two', ctypes.c_uint32)
-            ]
-
-        class Union(ctypes.Union):
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16),
-                ('c', ctypes.c_uint32),
-                ('d', Struct),
-            ]
-        expected = np.dtype(dict(
-            names=['a', 'b', 'c', 'd'],
-            formats=['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
-            offsets=[0, 0, 0, 0],
-            itemsize=ctypes.sizeof(Union)
-        ))
-        self.check(Union, expected)
-
-    def test_union_packed(self):
-        class Struct(ctypes.Structure):
-            _fields_ = [
-                ('one', ctypes.c_uint8),
-                ('two', ctypes.c_uint32)
-            ]
-            _pack_ = 1
-        class Union(ctypes.Union):
-            _pack_ = 1
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16),
-                ('c', ctypes.c_uint32),
-                ('d', Struct),
-            ]
-        expected = np.dtype(dict(
-            names=['a', 'b', 'c', 'd'],
-            formats=['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
-            offsets=[0, 0, 0, 0],
-            itemsize=ctypes.sizeof(Union)
-        ))
-        self.check(Union, expected)
-
-    def test_packed_structure(self):
-        class PackedStructure(ctypes.Structure):
-            _pack_ = 1
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16)
-            ]
-        expected = np.dtype([
-            ('a', np.uint8),
-            ('b', np.uint16)
-        ])
-        self.check(PackedStructure, expected)
-
-    def test_large_packed_structure(self):
-        class PackedStructure(ctypes.Structure):
-            _pack_ = 2
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16),
-                ('c', ctypes.c_uint8),
-                ('d', ctypes.c_uint16),
-                ('e', ctypes.c_uint32),
-                ('f', ctypes.c_uint32),
-                ('g', ctypes.c_uint8)
-                ]
-        expected = np.dtype(dict(
-            formats=[np.uint8, np.uint16, np.uint8, np.uint16, np.uint32, np.uint32, np.uint8 ],
-            offsets=[0, 2, 4, 6, 8, 12, 16],
-            names=['a', 'b', 'c', 'd', 'e', 'f', 'g'],
-            itemsize=18))
-        self.check(PackedStructure, expected)
-
-    def test_big_endian_structure_packed(self):
-        class BigEndStruct(ctypes.BigEndianStructure):
-            _fields_ = [
-                ('one', ctypes.c_uint8),
-                ('two', ctypes.c_uint32)
-            ]
-            _pack_ = 1
-        expected = np.dtype([('one', 'u1'), ('two', '>u4')])
-        self.check(BigEndStruct, expected)
-
-    def test_little_endian_structure_packed(self):
-        class LittleEndStruct(ctypes.LittleEndianStructure):
-            _fields_ = [
-                ('one', ctypes.c_uint8),
-                ('two', ctypes.c_uint32)
-            ]
-            _pack_ = 1
-        expected = np.dtype([('one', 'u1'), ('two', '<u4')])
-        self.check(LittleEndStruct, expected)
-
-    def test_little_endian_structure(self):
-        class PaddedStruct(ctypes.LittleEndianStructure):
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16)
-            ]
-        expected = np.dtype([
-            ('a', '<B'),
-            ('b', '<H')
-        ], align=True)
-        self.check(PaddedStruct, expected)
-
-    def test_big_endian_structure(self):
-        class PaddedStruct(ctypes.BigEndianStructure):
-            _fields_ = [
-                ('a', ctypes.c_uint8),
-                ('b', ctypes.c_uint16)
-            ]
-        expected = np.dtype([
-            ('a', '>B'),
-            ('b', '>H')
-        ], align=True)
-        self.check(PaddedStruct, expected)
-
-    def test_simple_endian_types(self):
-        self.check(ctypes.c_uint16.__ctype_le__, np.dtype('<u2'))
-        self.check(ctypes.c_uint16.__ctype_be__, np.dtype('>u2'))
-        self.check(ctypes.c_uint8.__ctype_le__, np.dtype('u1'))
-        self.check(ctypes.c_uint8.__ctype_be__, np.dtype('u1'))
-
-    all_types = set(np.typecodes['All'])
-    all_pairs = permutations(all_types, 2)
-
-    @pytest.mark.parametrize("pair", all_pairs)
-    def test_pairs(self, pair):
-        """
-        Check that np.dtype('x,y') matches [np.dtype('x'), np.dtype('y')]
-        Example: np.dtype('d,I') -> dtype([('f0', '<f8'), ('f1', '<u4')])
-        """
-        # gh-5645: check that np.dtype('i,L') can be used
-        pair_type = np.dtype('{},{}'.format(*pair))
-        expected = np.dtype([('f0', pair[0]), ('f1', pair[1])])
-        assert_equal(pair_type, expected)
-
-
-class TestUserDType:
-    @pytest.mark.leaks_references(reason="dynamically creates custom dtype.")
-    def test_custom_structured_dtype(self):
-        class mytype:
-            pass
-
-        blueprint = np.dtype([("field", object)])
-        dt = create_custom_field_dtype(blueprint, mytype, 0)
-        assert dt.type == mytype
-        # We cannot (currently) *create* this dtype with `np.dtype` because
-        # mytype does not inherit from `np.generic`.  This seems like an
-        # unnecessary restriction, but one that has been around forever:
-        assert np.dtype(mytype) == np.dtype("O")
-
-    def test_custom_structured_dtype_errors(self):
-        class mytype:
-            pass
-
-        blueprint = np.dtype([("field", object)])
-
-        with pytest.raises(ValueError):
-            # Tests what happens if fields are unset during creation
-            # which is currently rejected due to the containing object
-            # (see PyArray_RegisterDataType).
-            create_custom_field_dtype(blueprint, mytype, 1)
-
-        with pytest.raises(RuntimeError):
-            # Tests that a dtype must have its type field set up to np.dtype
-            # or in this case a builtin instance.
-            create_custom_field_dtype(blueprint, mytype, 2)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")

--- a/torch_np/tests/numpy_tests/core/test_dtype.py
+++ b/torch_np/tests/numpy_tests/core/test_dtype.py
@@ -4,15 +4,11 @@ import pytest
 import types
 from typing import Any
 
-import numpy as np
-from numpy.testing import (
-    assert_, assert_equal, assert_array_equal, assert_raises)
-from numpy.compat import pickle
-
 import torch_np as np
 from torch_np.testing import (
-    assert_, assert_equal, assert_array_equal, assert_raises)
-#from numpy.compat import pickle
+    assert_, assert_equal, assert_array_equal)
+from pytest import raises as assert_raises
+
 
 import pickle
 from itertools import permutations
@@ -248,28 +244,13 @@ class TestPromotion:
     """Test cases related to more complex DType promotions.  Further promotion
     tests are defined in `test_numeric.py`
     """
-###    @np._no_nep50_warning()
     @pytest.mark.parametrize(["other", "expected", "expected_weak"],
             [(2**16-1, np.complex64, None),
              (2**32-1, np.complex128, np.complex64),
              (np.float16(2), np.complex64, None),
              (np.float32(2), np.complex64, None),
-             (np.longdouble(2), np.complex64, np.clongdouble),
-             # Base of the double value to sidestep any rounding issues:
-             (np.longdouble(np.nextafter(1.7e308, 0.)),
-                  np.complex128, np.clongdouble),
-             # Additionally use "nextafter" so the cast can't round down:
-             (np.longdouble(np.nextafter(1.7e308, np.inf)),
-                  np.clongdouble, None),
              # repeat for complex scalars:
              (np.complex64(2), np.complex64, None),
-             (np.clongdouble(2), np.complex64, np.clongdouble),
-             # Base of the double value to sidestep any rounding issues:
-             (np.clongdouble(np.nextafter(1.7e308, 0.) * 1j),
-                  np.complex128, np.clongdouble),
-             # Additionally use "nextafter" so the cast can't round down:
-             (np.clongdouble(np.nextafter(1.7e308, np.inf)),
-                  np.clongdouble, None),
              ])
     def test_complex_other_value_based(self,
             weak_promotion, other, expected, expected_weak):
@@ -318,8 +299,8 @@ class TestPromotion:
 
     @pytest.mark.parametrize(["dtypes", "expected"], [
              # These promotions are not associative/commutative:
-             ([np.uint16, np.int16, np.float16], np.float32),
-             ([np.uint16, np.int8, np.float16], np.float32),
+             ([np.int16, np.float16], np.float32),
+             ([np.int8, np.float16], np.float32),
              ([np.uint8, np.int16, np.float16], np.float32),
              # The following promotions are not ambiguous, but cover code
              # paths of abstract promotion (no particular logic being tested)

--- a/torch_np/tests/numpy_tests/core/test_getlimits.py
+++ b/torch_np/tests/numpy_tests/core/test_getlimits.py
@@ -1,0 +1,147 @@
+""" Test functions for limits module.
+
+"""
+import warnings
+import numpy as np
+from numpy.core import finfo, iinfo
+from numpy import half, single, double, longdouble
+from numpy.testing import assert_equal, assert_, assert_raises
+from numpy.core.getlimits import _discovered_machar, _float_ma
+
+##################################################
+
+class TestPythonFloat:
+    def test_singleton(self):
+        ftype = finfo(float)
+        ftype2 = finfo(float)
+        assert_equal(id(ftype), id(ftype2))
+
+class TestHalf:
+    def test_singleton(self):
+        ftype = finfo(half)
+        ftype2 = finfo(half)
+        assert_equal(id(ftype), id(ftype2))
+
+class TestSingle:
+    def test_singleton(self):
+        ftype = finfo(single)
+        ftype2 = finfo(single)
+        assert_equal(id(ftype), id(ftype2))
+
+class TestDouble:
+    def test_singleton(self):
+        ftype = finfo(double)
+        ftype2 = finfo(double)
+        assert_equal(id(ftype), id(ftype2))
+
+class TestLongdouble:
+    def test_singleton(self):
+        ftype = finfo(longdouble)
+        ftype2 = finfo(longdouble)
+        assert_equal(id(ftype), id(ftype2))
+
+class TestFinfo:
+    def test_basic(self):
+        dts = list(zip(['f2', 'f4', 'f8', 'c8', 'c16'],
+                       [np.float16, np.float32, np.float64, np.complex64,
+                        np.complex128]))
+        for dt1, dt2 in dts:
+            for attr in ('bits', 'eps', 'epsneg', 'iexp', 'machep',
+                         'max', 'maxexp', 'min', 'minexp', 'negep', 'nexp',
+                         'nmant', 'precision', 'resolution', 'tiny',
+                         'smallest_normal', 'smallest_subnormal'):
+                assert_equal(getattr(finfo(dt1), attr),
+                             getattr(finfo(dt2), attr), attr)
+        assert_raises(ValueError, finfo, 'i4')
+
+class TestIinfo:
+    def test_basic(self):
+        dts = list(zip(['i1', 'i2', 'i4', 'i8',
+                   'u1', 'u2', 'u4', 'u8'],
+                  [np.int8, np.int16, np.int32, np.int64,
+                   np.uint8, np.uint16, np.uint32, np.uint64]))
+        for dt1, dt2 in dts:
+            for attr in ('bits', 'min', 'max'):
+                assert_equal(getattr(iinfo(dt1), attr),
+                             getattr(iinfo(dt2), attr), attr)
+        assert_raises(ValueError, iinfo, 'f4')
+
+    def test_unsigned_max(self):
+        types = np.sctypes['uint']
+        for T in types:
+            with np.errstate(over="ignore"):
+                max_calculated = T(0) - T(1)
+            assert_equal(iinfo(T).max, max_calculated)
+
+class TestRepr:
+    def test_iinfo_repr(self):
+        expected = "iinfo(min=-32768, max=32767, dtype=int16)"
+        assert_equal(repr(np.iinfo(np.int16)), expected)
+
+    def test_finfo_repr(self):
+        expected = "finfo(resolution=1e-06, min=-3.4028235e+38," + \
+                   " max=3.4028235e+38, dtype=float32)"
+        assert_equal(repr(np.finfo(np.float32)), expected)
+
+
+def test_instances():
+    iinfo(10)
+    finfo(3.0)
+
+
+def assert_ma_equal(discovered, ma_like):
+    # Check MachAr-like objects same as calculated MachAr instances
+    for key, value in discovered.__dict__.items():
+        assert_equal(value, getattr(ma_like, key))
+        if hasattr(value, 'shape'):
+            assert_equal(value.shape, getattr(ma_like, key).shape)
+            assert_equal(value.dtype, getattr(ma_like, key).dtype)
+
+
+def test_known_types():
+    # Test we are correctly compiling parameters for known types
+    for ftype, ma_like in ((np.float16, _float_ma[16]),
+                           (np.float32, _float_ma[32]),
+                           (np.float64, _float_ma[64])):
+        assert_ma_equal(_discovered_machar(ftype), ma_like)
+    # Suppress warning for broken discovery of double double on PPC
+    with np.errstate(all='ignore'):
+        ld_ma = _discovered_machar(np.longdouble)
+    bytes = np.dtype(np.longdouble).itemsize
+    if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
+        # 80-bit extended precision
+        assert_ma_equal(ld_ma, _float_ma[80])
+    elif (ld_ma.it, ld_ma.maxexp) == (112, 16384) and bytes == 16:
+        # IEE 754 128-bit
+        assert_ma_equal(ld_ma, _float_ma[128])
+
+
+def test_subnormal_warning():
+    """Test that the subnormal is zero warning is not being raised."""
+    with np.errstate(all='ignore'):
+        ld_ma = _discovered_machar(np.longdouble)
+    bytes = np.dtype(np.longdouble).itemsize
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
+            # 80-bit extended precision
+            ld_ma.smallest_subnormal
+            assert len(w) == 0
+        elif (ld_ma.it, ld_ma.maxexp) == (112, 16384) and bytes == 16:
+            # IEE 754 128-bit
+            ld_ma.smallest_subnormal
+            assert len(w) == 0
+        else:
+            # Double double
+            ld_ma.smallest_subnormal
+            # This test may fail on some platforms
+            assert len(w) == 0
+
+
+def test_plausible_finfo():
+    # Assert that finfo returns reasonable results for all types
+    for ftype in np.sctypes['float'] + np.sctypes['complex']:
+        info = np.finfo(ftype)
+        assert_(info.nmant > 1)
+        assert_(info.minexp < -1)
+        assert_(info.maxexp > 1)

--- a/torch_np/tests/numpy_tests/core/test_numerictypes.py
+++ b/torch_np/tests/numpy_tests/core/test_numerictypes.py
@@ -1,0 +1,564 @@
+import sys
+import itertools
+
+import pytest
+import numpy as np
+from numpy.testing import assert_, assert_equal, assert_raises, IS_PYPY
+
+# This is the structure of the table used for plain objects:
+#
+# +-+-+-+
+# |x|y|z|
+# +-+-+-+
+
+# Structure of a plain array description:
+Pdescr = [
+    ('x', 'i4', (2,)),
+    ('y', 'f8', (2, 2)),
+    ('z', 'u1')]
+
+# A plain list of tuples with values for testing:
+PbufferT = [
+    # x     y                  z
+    ([3, 2], [[6., 4.], [6., 4.]], 8),
+    ([4, 3], [[7., 5.], [7., 5.]], 9),
+    ]
+
+
+# This is the structure of the table used for nested objects (DON'T PANIC!):
+#
+# +-+---------------------------------+-----+----------+-+-+
+# |x|Info                             |color|info      |y|z|
+# | +-----+--+----------------+----+--+     +----+-----+ | |
+# | |value|y2|Info2           |name|z2|     |Name|Value| | |
+# | |     |  +----+-----+--+--+    |  |     |    |     | | |
+# | |     |  |name|value|y3|z3|    |  |     |    |     | | |
+# +-+-----+--+----+-----+--+--+----+--+-----+----+-----+-+-+
+#
+
+# The corresponding nested array description:
+Ndescr = [
+    ('x', 'i4', (2,)),
+    ('Info', [
+        ('value', 'c16'),
+        ('y2', 'f8'),
+        ('Info2', [
+            ('name', 'S2'),
+            ('value', 'c16', (2,)),
+            ('y3', 'f8', (2,)),
+            ('z3', 'u4', (2,))]),
+        ('name', 'S2'),
+        ('z2', 'b1')]),
+    ('color', 'S2'),
+    ('info', [
+        ('Name', 'U8'),
+        ('Value', 'c16')]),
+    ('y', 'f8', (2, 2)),
+    ('z', 'u1')]
+
+NbufferT = [
+    # x     Info                                                color info        y                  z
+    #       value y2 Info2                            name z2         Name Value
+    #                name   value    y3       z3
+    ([3, 2], (6j, 6., (b'nn', [6j, 4j], [6., 4.], [1, 2]), b'NN', True),
+     b'cc', ('NN', 6j), [[6., 4.], [6., 4.]], 8),
+    ([4, 3], (7j, 7., (b'oo', [7j, 5j], [7., 5.], [2, 1]), b'OO', False),
+     b'dd', ('OO', 7j), [[7., 5.], [7., 5.]], 9),
+    ]
+
+
+byteorder = {'little':'<', 'big':'>'}[sys.byteorder]
+
+def normalize_descr(descr):
+    "Normalize a description adding the platform byteorder."
+
+    out = []
+    for item in descr:
+        dtype = item[1]
+        if isinstance(dtype, str):
+            if dtype[0] not in ['|', '<', '>']:
+                onebyte = dtype[1:] == "1"
+                if onebyte or dtype[0] in ['S', 'V', 'b']:
+                    dtype = "|" + dtype
+                else:
+                    dtype = byteorder + dtype
+            if len(item) > 2 and np.prod(item[2]) > 1:
+                nitem = (item[0], dtype, item[2])
+            else:
+                nitem = (item[0], dtype)
+            out.append(nitem)
+        elif isinstance(dtype, list):
+            l = normalize_descr(dtype)
+            out.append((item[0], l))
+        else:
+            raise ValueError("Expected a str or list and got %s" %
+                             (type(item)))
+    return out
+
+
+############################################################
+#    Creation tests
+############################################################
+
+class CreateZeros:
+    """Check the creation of heterogeneous arrays zero-valued"""
+
+    def test_zeros0D(self):
+        """Check creation of 0-dimensional objects"""
+        h = np.zeros((), dtype=self._descr)
+        assert_(normalize_descr(self._descr) == h.dtype.descr)
+        assert_(h.dtype.fields['x'][0].name[:4] == 'void')
+        assert_(h.dtype.fields['x'][0].char == 'V')
+        assert_(h.dtype.fields['x'][0].type == np.void)
+        # A small check that data is ok
+        assert_equal(h['z'], np.zeros((), dtype='u1'))
+
+    def test_zerosSD(self):
+        """Check creation of single-dimensional objects"""
+        h = np.zeros((2,), dtype=self._descr)
+        assert_(normalize_descr(self._descr) == h.dtype.descr)
+        assert_(h.dtype['y'].name[:4] == 'void')
+        assert_(h.dtype['y'].char == 'V')
+        assert_(h.dtype['y'].type == np.void)
+        # A small check that data is ok
+        assert_equal(h['z'], np.zeros((2,), dtype='u1'))
+
+    def test_zerosMD(self):
+        """Check creation of multi-dimensional objects"""
+        h = np.zeros((2, 3), dtype=self._descr)
+        assert_(normalize_descr(self._descr) == h.dtype.descr)
+        assert_(h.dtype['z'].name == 'uint8')
+        assert_(h.dtype['z'].char == 'B')
+        assert_(h.dtype['z'].type == np.uint8)
+        # A small check that data is ok
+        assert_equal(h['z'], np.zeros((2, 3), dtype='u1'))
+
+
+class TestCreateZerosPlain(CreateZeros):
+    """Check the creation of heterogeneous arrays zero-valued (plain)"""
+    _descr = Pdescr
+
+class TestCreateZerosNested(CreateZeros):
+    """Check the creation of heterogeneous arrays zero-valued (nested)"""
+    _descr = Ndescr
+
+
+class CreateValues:
+    """Check the creation of heterogeneous arrays with values"""
+
+    def test_tuple(self):
+        """Check creation from tuples"""
+        h = np.array(self._buffer, dtype=self._descr)
+        assert_(normalize_descr(self._descr) == h.dtype.descr)
+        if self.multiple_rows:
+            assert_(h.shape == (2,))
+        else:
+            assert_(h.shape == ())
+
+    def test_list_of_tuple(self):
+        """Check creation from list of tuples"""
+        h = np.array([self._buffer], dtype=self._descr)
+        assert_(normalize_descr(self._descr) == h.dtype.descr)
+        if self.multiple_rows:
+            assert_(h.shape == (1, 2))
+        else:
+            assert_(h.shape == (1,))
+
+    def test_list_of_list_of_tuple(self):
+        """Check creation from list of list of tuples"""
+        h = np.array([[self._buffer]], dtype=self._descr)
+        assert_(normalize_descr(self._descr) == h.dtype.descr)
+        if self.multiple_rows:
+            assert_(h.shape == (1, 1, 2))
+        else:
+            assert_(h.shape == (1, 1))
+
+
+class TestCreateValuesPlainSingle(CreateValues):
+    """Check the creation of heterogeneous arrays (plain, single row)"""
+    _descr = Pdescr
+    multiple_rows = 0
+    _buffer = PbufferT[0]
+
+class TestCreateValuesPlainMultiple(CreateValues):
+    """Check the creation of heterogeneous arrays (plain, multiple rows)"""
+    _descr = Pdescr
+    multiple_rows = 1
+    _buffer = PbufferT
+
+class TestCreateValuesNestedSingle(CreateValues):
+    """Check the creation of heterogeneous arrays (nested, single row)"""
+    _descr = Ndescr
+    multiple_rows = 0
+    _buffer = NbufferT[0]
+
+class TestCreateValuesNestedMultiple(CreateValues):
+    """Check the creation of heterogeneous arrays (nested, multiple rows)"""
+    _descr = Ndescr
+    multiple_rows = 1
+    _buffer = NbufferT
+
+
+############################################################
+#    Reading tests
+############################################################
+
+class ReadValuesPlain:
+    """Check the reading of values in heterogeneous arrays (plain)"""
+
+    def test_access_fields(self):
+        h = np.array(self._buffer, dtype=self._descr)
+        if not self.multiple_rows:
+            assert_(h.shape == ())
+            assert_equal(h['x'], np.array(self._buffer[0], dtype='i4'))
+            assert_equal(h['y'], np.array(self._buffer[1], dtype='f8'))
+            assert_equal(h['z'], np.array(self._buffer[2], dtype='u1'))
+        else:
+            assert_(len(h) == 2)
+            assert_equal(h['x'], np.array([self._buffer[0][0],
+                                             self._buffer[1][0]], dtype='i4'))
+            assert_equal(h['y'], np.array([self._buffer[0][1],
+                                             self._buffer[1][1]], dtype='f8'))
+            assert_equal(h['z'], np.array([self._buffer[0][2],
+                                             self._buffer[1][2]], dtype='u1'))
+
+
+class TestReadValuesPlainSingle(ReadValuesPlain):
+    """Check the creation of heterogeneous arrays (plain, single row)"""
+    _descr = Pdescr
+    multiple_rows = 0
+    _buffer = PbufferT[0]
+
+class TestReadValuesPlainMultiple(ReadValuesPlain):
+    """Check the values of heterogeneous arrays (plain, multiple rows)"""
+    _descr = Pdescr
+    multiple_rows = 1
+    _buffer = PbufferT
+
+class ReadValuesNested:
+    """Check the reading of values in heterogeneous arrays (nested)"""
+
+    def test_access_top_fields(self):
+        """Check reading the top fields of a nested array"""
+        h = np.array(self._buffer, dtype=self._descr)
+        if not self.multiple_rows:
+            assert_(h.shape == ())
+            assert_equal(h['x'], np.array(self._buffer[0], dtype='i4'))
+            assert_equal(h['y'], np.array(self._buffer[4], dtype='f8'))
+            assert_equal(h['z'], np.array(self._buffer[5], dtype='u1'))
+        else:
+            assert_(len(h) == 2)
+            assert_equal(h['x'], np.array([self._buffer[0][0],
+                                           self._buffer[1][0]], dtype='i4'))
+            assert_equal(h['y'], np.array([self._buffer[0][4],
+                                           self._buffer[1][4]], dtype='f8'))
+            assert_equal(h['z'], np.array([self._buffer[0][5],
+                                           self._buffer[1][5]], dtype='u1'))
+
+    def test_nested1_acessors(self):
+        """Check reading the nested fields of a nested array (1st level)"""
+        h = np.array(self._buffer, dtype=self._descr)
+        if not self.multiple_rows:
+            assert_equal(h['Info']['value'],
+                         np.array(self._buffer[1][0], dtype='c16'))
+            assert_equal(h['Info']['y2'],
+                         np.array(self._buffer[1][1], dtype='f8'))
+            assert_equal(h['info']['Name'],
+                         np.array(self._buffer[3][0], dtype='U2'))
+            assert_equal(h['info']['Value'],
+                         np.array(self._buffer[3][1], dtype='c16'))
+        else:
+            assert_equal(h['Info']['value'],
+                         np.array([self._buffer[0][1][0],
+                                self._buffer[1][1][0]],
+                                dtype='c16'))
+            assert_equal(h['Info']['y2'],
+                         np.array([self._buffer[0][1][1],
+                                self._buffer[1][1][1]],
+                                dtype='f8'))
+            assert_equal(h['info']['Name'],
+                         np.array([self._buffer[0][3][0],
+                                self._buffer[1][3][0]],
+                               dtype='U2'))
+            assert_equal(h['info']['Value'],
+                         np.array([self._buffer[0][3][1],
+                                self._buffer[1][3][1]],
+                               dtype='c16'))
+
+    def test_nested2_acessors(self):
+        """Check reading the nested fields of a nested array (2nd level)"""
+        h = np.array(self._buffer, dtype=self._descr)
+        if not self.multiple_rows:
+            assert_equal(h['Info']['Info2']['value'],
+                         np.array(self._buffer[1][2][1], dtype='c16'))
+            assert_equal(h['Info']['Info2']['z3'],
+                         np.array(self._buffer[1][2][3], dtype='u4'))
+        else:
+            assert_equal(h['Info']['Info2']['value'],
+                         np.array([self._buffer[0][1][2][1],
+                                self._buffer[1][1][2][1]],
+                               dtype='c16'))
+            assert_equal(h['Info']['Info2']['z3'],
+                         np.array([self._buffer[0][1][2][3],
+                                self._buffer[1][1][2][3]],
+                               dtype='u4'))
+
+    def test_nested1_descriptor(self):
+        """Check access nested descriptors of a nested array (1st level)"""
+        h = np.array(self._buffer, dtype=self._descr)
+        assert_(h.dtype['Info']['value'].name == 'complex128')
+        assert_(h.dtype['Info']['y2'].name == 'float64')
+        assert_(h.dtype['info']['Name'].name == 'str256')
+        assert_(h.dtype['info']['Value'].name == 'complex128')
+
+    def test_nested2_descriptor(self):
+        """Check access nested descriptors of a nested array (2nd level)"""
+        h = np.array(self._buffer, dtype=self._descr)
+        assert_(h.dtype['Info']['Info2']['value'].name == 'void256')
+        assert_(h.dtype['Info']['Info2']['z3'].name == 'void64')
+
+
+class TestReadValuesNestedSingle(ReadValuesNested):
+    """Check the values of heterogeneous arrays (nested, single row)"""
+    _descr = Ndescr
+    multiple_rows = False
+    _buffer = NbufferT[0]
+
+class TestReadValuesNestedMultiple(ReadValuesNested):
+    """Check the values of heterogeneous arrays (nested, multiple rows)"""
+    _descr = Ndescr
+    multiple_rows = True
+    _buffer = NbufferT
+
+class TestEmptyField:
+    def test_assign(self):
+        a = np.arange(10, dtype=np.float32)
+        a.dtype = [("int",   "<0i4"), ("float", "<2f4")]
+        assert_(a['int'].shape == (5, 0))
+        assert_(a['float'].shape == (5, 2))
+
+class TestCommonType:
+    def test_scalar_loses1(self):
+        res = np.find_common_type(['f4', 'f4', 'i2'], ['f8'])
+        assert_(res == 'f4')
+
+    def test_scalar_loses2(self):
+        res = np.find_common_type(['f4', 'f4'], ['i8'])
+        assert_(res == 'f4')
+
+    def test_scalar_wins(self):
+        res = np.find_common_type(['f4', 'f4', 'i2'], ['c8'])
+        assert_(res == 'c8')
+
+    def test_scalar_wins2(self):
+        res = np.find_common_type(['u4', 'i4', 'i4'], ['f4'])
+        assert_(res == 'f8')
+
+    def test_scalar_wins3(self):  # doesn't go up to 'f16' on purpose
+        res = np.find_common_type(['u8', 'i8', 'i8'], ['f8'])
+        assert_(res == 'f8')
+
+class TestMultipleFields:
+    def setup_method(self):
+        self.ary = np.array([(1, 2, 3, 4), (5, 6, 7, 8)], dtype='i4,f4,i2,c8')
+
+    def _bad_call(self):
+        return self.ary['f0', 'f1']
+
+    def test_no_tuple(self):
+        assert_raises(IndexError, self._bad_call)
+
+    def test_return(self):
+        res = self.ary[['f0', 'f2']].tolist()
+        assert_(res == [(1, 3), (5, 7)])
+
+
+class TestIsSubDType:
+    # scalar types can be promoted into dtypes
+    wrappers = [np.dtype, lambda x: x]
+
+    def test_both_abstract(self):
+        assert_(np.issubdtype(np.floating, np.inexact))
+        assert_(not np.issubdtype(np.inexact, np.floating))
+
+    def test_same(self):
+        for cls in (np.float32, np.int32):
+            for w1, w2 in itertools.product(self.wrappers, repeat=2):
+                assert_(np.issubdtype(w1(cls), w2(cls)))
+
+    def test_subclass(self):
+        # note we cannot promote floating to a dtype, as it would turn into a
+        # concrete type
+        for w in self.wrappers:
+            assert_(np.issubdtype(w(np.float32), np.floating))
+            assert_(np.issubdtype(w(np.float64), np.floating))
+
+    def test_subclass_backwards(self):
+        for w in self.wrappers:
+            assert_(not np.issubdtype(np.floating, w(np.float32)))
+            assert_(not np.issubdtype(np.floating, w(np.float64)))
+
+    def test_sibling_class(self):
+        for w1, w2 in itertools.product(self.wrappers, repeat=2):
+            assert_(not np.issubdtype(w1(np.float32), w2(np.float64)))
+            assert_(not np.issubdtype(w1(np.float64), w2(np.float32)))
+
+    def test_nondtype_nonscalartype(self):
+        # See gh-14619 and gh-9505 which introduced the deprecation to fix
+        # this. These tests are directly taken from gh-9505
+        assert not np.issubdtype(np.float32, 'float64')
+        assert not np.issubdtype(np.float32, 'f8')
+        assert not np.issubdtype(np.int32, str)
+        assert not np.issubdtype(np.int32, 'int64')
+        assert not np.issubdtype(np.str_, 'void')
+        # for the following the correct spellings are
+        # np.integer, np.floating, or np.complexfloating respectively:
+        assert not np.issubdtype(np.int8, int)  # np.int8 is never np.int_
+        assert not np.issubdtype(np.float32, float)
+        assert not np.issubdtype(np.complex64, complex)
+        assert not np.issubdtype(np.float32, "float")
+        assert not np.issubdtype(np.float64, "f")
+
+        # Test the same for the correct first datatype and abstract one
+        # in the case of int, float, complex:
+        assert np.issubdtype(np.float64, 'float64')
+        assert np.issubdtype(np.float64, 'f8')
+        assert np.issubdtype(np.str_, str)
+        assert np.issubdtype(np.int64, 'int64')
+        assert np.issubdtype(np.void, 'void')
+        assert np.issubdtype(np.int8, np.integer)
+        assert np.issubdtype(np.float32, np.floating)
+        assert np.issubdtype(np.complex64, np.complexfloating)
+        assert np.issubdtype(np.float64, "float")
+        assert np.issubdtype(np.float32, "f")
+
+
+class TestSctypeDict:
+    def test_longdouble(self):
+        assert_(np.sctypeDict['f8'] is not np.longdouble)
+        assert_(np.sctypeDict['c16'] is not np.clongdouble)
+
+    def test_ulong(self):
+        # Test that 'ulong' behaves like 'long'. np.sctypeDict['long'] is an
+        # alias for np.int_, but np.long is not supported for historical
+        # reasons (gh-21063)
+        assert_(np.sctypeDict['ulong'] is np.uint)
+        with pytest.warns(FutureWarning):
+            # We will probably allow this in the future:
+            assert not hasattr(np, 'ulong')
+
+class TestBitName:
+    def test_abstract(self):
+        assert_raises(ValueError, np.core.numerictypes.bitname, np.floating)
+
+
+class TestMaximumSctype:
+
+    # note that parametrizing with sctype['int'] and similar would skip types
+    # with the same size (gh-11923)
+
+    @pytest.mark.parametrize('t', [np.byte, np.short, np.intc, np.int_, np.longlong])
+    def test_int(self, t):
+        assert_equal(np.maximum_sctype(t), np.sctypes['int'][-1])
+
+    @pytest.mark.parametrize('t', [np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong])
+    def test_uint(self, t):
+        assert_equal(np.maximum_sctype(t), np.sctypes['uint'][-1])
+
+    @pytest.mark.parametrize('t', [np.half, np.single, np.double, np.longdouble])
+    def test_float(self, t):
+        assert_equal(np.maximum_sctype(t), np.sctypes['float'][-1])
+
+    @pytest.mark.parametrize('t', [np.csingle, np.cdouble, np.clongdouble])
+    def test_complex(self, t):
+        assert_equal(np.maximum_sctype(t), np.sctypes['complex'][-1])
+
+    @pytest.mark.parametrize('t', [np.bool_, np.object_, np.unicode_, np.bytes_, np.void])
+    def test_other(self, t):
+        assert_equal(np.maximum_sctype(t), t)
+
+
+class Test_sctype2char:
+    # This function is old enough that we're really just documenting the quirks
+    # at this point.
+
+    def test_scalar_type(self):
+        assert_equal(np.sctype2char(np.double), 'd')
+        assert_equal(np.sctype2char(np.int_), 'l')
+        assert_equal(np.sctype2char(np.unicode_), 'U')
+        assert_equal(np.sctype2char(np.bytes_), 'S')
+
+    def test_other_type(self):
+        assert_equal(np.sctype2char(float), 'd')
+        assert_equal(np.sctype2char(list), 'O')
+        assert_equal(np.sctype2char(np.ndarray), 'O')
+
+    def test_third_party_scalar_type(self):
+        from numpy.core._rational_tests import rational
+        assert_raises(KeyError, np.sctype2char, rational)
+        assert_raises(KeyError, np.sctype2char, rational(1))
+
+    def test_array_instance(self):
+        assert_equal(np.sctype2char(np.array([1.0, 2.0])), 'd')
+
+    def test_abstract_type(self):
+        assert_raises(KeyError, np.sctype2char, np.floating)
+
+    def test_non_type(self):
+        assert_raises(ValueError, np.sctype2char, 1)
+
+@pytest.mark.parametrize("rep, expected", [
+    (np.int32, True),
+    (list, False),
+    (1.1, False),
+    (str, True),
+    (np.dtype(np.float64), True),
+    (np.dtype((np.int16, (3, 4))), True),
+    (np.dtype([('a', np.int8)]), True),
+    ])
+def test_issctype(rep, expected):
+    # ensure proper identification of scalar
+    # data-types by issctype()
+    actual = np.issctype(rep)
+    assert_equal(actual, expected)
+
+
+@pytest.mark.skipif(sys.flags.optimize > 1,
+                    reason="no docstrings present to inspect when PYTHONOPTIMIZE/Py_OptimizeFlag > 1")
+@pytest.mark.xfail(IS_PYPY,
+                   reason="PyPy cannot modify tp_doc after PyType_Ready")
+class TestDocStrings:
+    def test_platform_dependent_aliases(self):
+        if np.int64 is np.int_:
+            assert_('int64' in np.int_.__doc__)
+        elif np.int64 is np.longlong:
+            assert_('int64' in np.longlong.__doc__)
+
+
+class TestScalarTypeNames:
+    # gh-9799
+
+    numeric_types = [
+        np.byte, np.short, np.intc, np.int_, np.longlong,
+        np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong,
+        np.half, np.single, np.double, np.longdouble,
+        np.csingle, np.cdouble, np.clongdouble,
+    ]
+
+    def test_names_are_unique(self):
+        # none of the above may be aliases for each other
+        assert len(set(self.numeric_types)) == len(self.numeric_types)
+
+        # names must be unique
+        names = [t.__name__ for t in self.numeric_types]
+        assert len(set(names)) == len(names)
+
+    @pytest.mark.parametrize('t', numeric_types)
+    def test_names_reflect_attributes(self, t):
+        """ Test that names correspond to where the type is under ``np.`` """
+        assert getattr(np, t.__name__) is t
+
+    @pytest.mark.parametrize('t', numeric_types)
+    def test_names_are_undersood_by_dtype(self, t):
+        """ Test the dtype constructor maps names back to the type """
+        assert np.dtype(t.__name__).type is t

--- a/torch_np/tests/numpy_tests/core/test_scalar_ctors.py
+++ b/torch_np/tests/numpy_tests/core/test_scalar_ctors.py
@@ -1,0 +1,186 @@
+"""
+Test the scalar constructors, which also do type-coercion
+"""
+import pytest
+
+import numpy as np
+from numpy.testing import (
+    assert_equal, assert_almost_equal, assert_warns,
+    )
+
+class TestFromString:
+    def test_floating(self):
+        # Ticket #640, floats from string
+        fsingle = np.single('1.234')
+        fdouble = np.double('1.234')
+        flongdouble = np.longdouble('1.234')
+        assert_almost_equal(fsingle, 1.234)
+        assert_almost_equal(fdouble, 1.234)
+        assert_almost_equal(flongdouble, 1.234)
+
+    def test_floating_overflow(self):
+        """ Strings containing an unrepresentable float overflow """
+        fhalf = np.half('1e10000')
+        assert_equal(fhalf, np.inf)
+        fsingle = np.single('1e10000')
+        assert_equal(fsingle, np.inf)
+        fdouble = np.double('1e10000')
+        assert_equal(fdouble, np.inf)
+        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '1e10000')
+        assert_equal(flongdouble, np.inf)
+
+        fhalf = np.half('-1e10000')
+        assert_equal(fhalf, -np.inf)
+        fsingle = np.single('-1e10000')
+        assert_equal(fsingle, -np.inf)
+        fdouble = np.double('-1e10000')
+        assert_equal(fdouble, -np.inf)
+        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '-1e10000')
+        assert_equal(flongdouble, -np.inf)
+
+
+class TestExtraArgs:
+    def test_superclass(self):
+        # try both positional and keyword arguments
+        s = np.str_(b'\\x61', encoding='unicode-escape')
+        assert s == 'a'
+        s = np.str_(b'\\x61', 'unicode-escape')
+        assert s == 'a'
+
+        # previously this would return '\\xx'
+        with pytest.raises(UnicodeDecodeError):
+            np.str_(b'\\xx', encoding='unicode-escape')
+        with pytest.raises(UnicodeDecodeError):
+            np.str_(b'\\xx', 'unicode-escape')
+
+        # superclass fails, but numpy succeeds
+        assert np.bytes_(-2) == b'-2'
+
+    def test_datetime(self):
+        dt = np.datetime64('2000-01', ('M', 2))
+        assert np.datetime_data(dt) == ('M', 2)
+
+        with pytest.raises(TypeError):
+            np.datetime64('2000', garbage=True)
+
+    def test_bool(self):
+        with pytest.raises(TypeError):
+            np.bool_(False, garbage=True)
+
+    def test_void(self):
+        with pytest.raises(TypeError):
+            np.void(b'test', garbage=True)
+
+
+class TestFromInt:
+    def test_intp(self):
+        # Ticket #99
+        assert_equal(1024, np.intp(1024))
+
+    def test_uint64_from_negative(self):
+        with pytest.warns(DeprecationWarning):
+            assert_equal(np.uint64(-2), np.uint64(18446744073709551614))
+
+
+int_types = [np.byte, np.short, np.intc, np.int_, np.longlong]
+uint_types = [np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong]
+float_types = [np.half, np.single, np.double, np.longdouble]
+cfloat_types = [np.csingle, np.cdouble, np.clongdouble]
+
+
+class TestArrayFromScalar:
+    """ gh-15467 """
+
+    def _do_test(self, t1, t2):
+        x = t1(2)
+        arr = np.array(x, dtype=t2)
+        # type should be preserved exactly
+        if t2 is None:
+            assert arr.dtype.type is t1
+        else:
+            assert arr.dtype.type is t2
+
+    @pytest.mark.parametrize('t1', int_types + uint_types)
+    @pytest.mark.parametrize('t2', int_types + uint_types + [None])
+    def test_integers(self, t1, t2):
+        return self._do_test(t1, t2)
+
+    @pytest.mark.parametrize('t1', float_types)
+    @pytest.mark.parametrize('t2', float_types + [None])
+    def test_reals(self, t1, t2):
+        return self._do_test(t1, t2)
+
+    @pytest.mark.parametrize('t1', cfloat_types)
+    @pytest.mark.parametrize('t2', cfloat_types + [None])
+    def test_complex(self, t1, t2):
+        return self._do_test(t1, t2)
+
+
+@pytest.mark.parametrize("length",
+        [5, np.int8(5), np.array(5, dtype=np.uint16)])
+def test_void_via_length(length):
+    res = np.void(length)
+    assert type(res) is np.void
+    assert res.item() == b"\0" * 5
+    assert res.dtype == "V5"
+
+@pytest.mark.parametrize("bytes_",
+        [b"spam", np.array(567.)])
+def test_void_from_byteslike(bytes_):
+    res = np.void(bytes_)
+    expected = bytes(bytes_)
+    assert type(res) is np.void
+    assert res.item() == expected
+
+    # Passing dtype can extend it (this is how filling works)
+    res = np.void(bytes_, dtype="V100")
+    assert type(res) is np.void
+    assert res.item()[:len(expected)] == expected
+    assert res.item()[len(expected):] == b"\0" * (res.nbytes - len(expected))
+    # As well as shorten:
+    res = np.void(bytes_, dtype="V4")
+    assert type(res) is np.void
+    assert res.item() == expected[:4]
+
+def test_void_arraylike_trumps_byteslike():
+    # The memoryview is converted as an array-like of shape (18,)
+    # rather than a single bytes-like of that length.
+    m = memoryview(b"just one mintleaf?")
+    res = np.void(m)
+    assert type(res) is np.ndarray
+    assert res.dtype == "V1"
+    assert res.shape == (18,)
+
+def test_void_dtype_arg():
+    # Basic test for the dtype argument (positional and keyword)
+    res = np.void((1, 2), dtype="i,i")
+    assert res.item() == (1, 2)
+    res = np.void((2, 3), "i,i")
+    assert res.item() == (2, 3)
+
+@pytest.mark.parametrize("data",
+        [5, np.int8(5), np.array(5, dtype=np.uint16)])
+def test_void_from_integer_with_dtype(data):
+    # The "length" meaning is ignored, rather data is used:
+    res = np.void(data, dtype="i,i")
+    assert type(res) is np.void
+    assert res.dtype == "i,i"
+    assert res["f0"] == 5 and res["f1"] == 5
+
+def test_void_from_structure():
+    dtype = np.dtype([('s', [('f', 'f8'), ('u', 'U1')]), ('i', 'i2')])
+    data = np.array(((1., 'a'), 2), dtype=dtype)
+    res = np.void(data[()], dtype=dtype)
+    assert type(res) is np.void
+    assert res.dtype == dtype
+    assert res == data[()]
+
+def test_void_bad_dtype():
+    with pytest.raises(TypeError,
+            match="void: descr must be a `void.*int64"):
+        np.void(4, dtype="i8")
+
+    # Subarray dtype (with shape `(4,)` is rejected):
+    with pytest.raises(TypeError,
+            match=r"void: descr must be a `void.*\(4,\)"):
+        np.void(4, dtype="4i")

--- a/torch_np/tests/numpy_tests/core/test_scalar_ctors.py
+++ b/torch_np/tests/numpy_tests/core/test_scalar_ctors.py
@@ -3,8 +3,8 @@ Test the scalar constructors, which also do type-coercion
 """
 import pytest
 
-import numpy as np
-from numpy.testing import (
+import torch_np as np
+from torch_np.testing import (
     assert_equal, assert_almost_equal, assert_warns,
     )
 
@@ -13,10 +13,8 @@ class TestFromString:
         # Ticket #640, floats from string
         fsingle = np.single('1.234')
         fdouble = np.double('1.234')
-        flongdouble = np.longdouble('1.234')
         assert_almost_equal(fsingle, 1.234)
         assert_almost_equal(fdouble, 1.234)
-        assert_almost_equal(flongdouble, 1.234)
 
     def test_floating_overflow(self):
         """ Strings containing an unrepresentable float overflow """
@@ -26,8 +24,6 @@ class TestFromString:
         assert_equal(fsingle, np.inf)
         fdouble = np.double('1e10000')
         assert_equal(fdouble, np.inf)
-        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '1e10000')
-        assert_equal(flongdouble, np.inf)
 
         fhalf = np.half('-1e10000')
         assert_equal(fhalf, -np.inf)
@@ -35,41 +31,11 @@ class TestFromString:
         assert_equal(fsingle, -np.inf)
         fdouble = np.double('-1e10000')
         assert_equal(fdouble, -np.inf)
-        flongdouble = assert_warns(RuntimeWarning, np.longdouble, '-1e10000')
-        assert_equal(flongdouble, -np.inf)
 
-
-class TestExtraArgs:
-    def test_superclass(self):
-        # try both positional and keyword arguments
-        s = np.str_(b'\\x61', encoding='unicode-escape')
-        assert s == 'a'
-        s = np.str_(b'\\x61', 'unicode-escape')
-        assert s == 'a'
-
-        # previously this would return '\\xx'
-        with pytest.raises(UnicodeDecodeError):
-            np.str_(b'\\xx', encoding='unicode-escape')
-        with pytest.raises(UnicodeDecodeError):
-            np.str_(b'\\xx', 'unicode-escape')
-
-        # superclass fails, but numpy succeeds
-        assert np.bytes_(-2) == b'-2'
-
-    def test_datetime(self):
-        dt = np.datetime64('2000-01', ('M', 2))
-        assert np.datetime_data(dt) == ('M', 2)
-
-        with pytest.raises(TypeError):
-            np.datetime64('2000', garbage=True)
 
     def test_bool(self):
         with pytest.raises(TypeError):
             np.bool_(False, garbage=True)
-
-    def test_void(self):
-        with pytest.raises(TypeError):
-            np.void(b'test', garbage=True)
 
 
 class TestFromInt:
@@ -83,9 +49,9 @@ class TestFromInt:
 
 
 int_types = [np.byte, np.short, np.intc, np.int_, np.longlong]
-uint_types = [np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong]
-float_types = [np.half, np.single, np.double, np.longdouble]
-cfloat_types = [np.csingle, np.cdouble, np.clongdouble]
+uint_types = [np.ubyte]
+float_types = [np.half, np.single, np.double]
+cfloat_types = [np.csingle, np.cdouble]
 
 
 class TestArrayFromScalar:
@@ -115,72 +81,3 @@ class TestArrayFromScalar:
     def test_complex(self, t1, t2):
         return self._do_test(t1, t2)
 
-
-@pytest.mark.parametrize("length",
-        [5, np.int8(5), np.array(5, dtype=np.uint16)])
-def test_void_via_length(length):
-    res = np.void(length)
-    assert type(res) is np.void
-    assert res.item() == b"\0" * 5
-    assert res.dtype == "V5"
-
-@pytest.mark.parametrize("bytes_",
-        [b"spam", np.array(567.)])
-def test_void_from_byteslike(bytes_):
-    res = np.void(bytes_)
-    expected = bytes(bytes_)
-    assert type(res) is np.void
-    assert res.item() == expected
-
-    # Passing dtype can extend it (this is how filling works)
-    res = np.void(bytes_, dtype="V100")
-    assert type(res) is np.void
-    assert res.item()[:len(expected)] == expected
-    assert res.item()[len(expected):] == b"\0" * (res.nbytes - len(expected))
-    # As well as shorten:
-    res = np.void(bytes_, dtype="V4")
-    assert type(res) is np.void
-    assert res.item() == expected[:4]
-
-def test_void_arraylike_trumps_byteslike():
-    # The memoryview is converted as an array-like of shape (18,)
-    # rather than a single bytes-like of that length.
-    m = memoryview(b"just one mintleaf?")
-    res = np.void(m)
-    assert type(res) is np.ndarray
-    assert res.dtype == "V1"
-    assert res.shape == (18,)
-
-def test_void_dtype_arg():
-    # Basic test for the dtype argument (positional and keyword)
-    res = np.void((1, 2), dtype="i,i")
-    assert res.item() == (1, 2)
-    res = np.void((2, 3), "i,i")
-    assert res.item() == (2, 3)
-
-@pytest.mark.parametrize("data",
-        [5, np.int8(5), np.array(5, dtype=np.uint16)])
-def test_void_from_integer_with_dtype(data):
-    # The "length" meaning is ignored, rather data is used:
-    res = np.void(data, dtype="i,i")
-    assert type(res) is np.void
-    assert res.dtype == "i,i"
-    assert res["f0"] == 5 and res["f1"] == 5
-
-def test_void_from_structure():
-    dtype = np.dtype([('s', [('f', 'f8'), ('u', 'U1')]), ('i', 'i2')])
-    data = np.array(((1., 'a'), 2), dtype=dtype)
-    res = np.void(data[()], dtype=dtype)
-    assert type(res) is np.void
-    assert res.dtype == dtype
-    assert res == data[()]
-
-def test_void_bad_dtype():
-    with pytest.raises(TypeError,
-            match="void: descr must be a `void.*int64"):
-        np.void(4, dtype="i8")
-
-    # Subarray dtype (with shape `(4,)` is rejected):
-    with pytest.raises(TypeError,
-            match=r"void: descr must be a `void.*\(4,\)"):
-        np.void(4, dtype="4i")

--- a/torch_np/tests/numpy_tests/core/test_scalar_ctors.py
+++ b/torch_np/tests/numpy_tests/core/test_scalar_ctors.py
@@ -8,7 +8,9 @@ from torch_np.testing import (
     assert_equal, assert_almost_equal, assert_warns,
     )
 
+
 class TestFromString:
+    @pytest.mark.xfail(reason='XXX: floats from strings')
     def test_floating(self):
         # Ticket #640, floats from string
         fsingle = np.single('1.234')
@@ -16,6 +18,7 @@ class TestFromString:
         assert_almost_equal(fsingle, 1.234)
         assert_almost_equal(fdouble, 1.234)
 
+    @pytest.mark.xfail(reason='XXX: floats from strings')
     def test_floating_overflow(self):
         """ Strings containing an unrepresentable float overflow """
         fhalf = np.half('1e10000')
@@ -32,7 +35,6 @@ class TestFromString:
         fdouble = np.double('-1e10000')
         assert_equal(fdouble, -np.inf)
 
-
     def test_bool(self):
         with pytest.raises(TypeError):
             np.bool_(False, garbage=True)
@@ -44,8 +46,8 @@ class TestFromInt:
         assert_equal(1024, np.intp(1024))
 
     def test_uint64_from_negative(self):
-        with pytest.warns(DeprecationWarning):
-            assert_equal(np.uint64(-2), np.uint64(18446744073709551614))
+        # NumPy test was asserting a DeprecationWarning
+        assert_equal(np.uint8(-2), np.uint8(254))
 
 
 int_types = [np.byte, np.short, np.intc, np.int_, np.longlong]
@@ -65,6 +67,12 @@ class TestArrayFromScalar:
             assert arr.dtype.type is t1
         else:
             assert arr.dtype.type is t2
+
+        arr1 = np.asarray(x, dtype=t2)
+        if t2 is None:
+            assert arr1.dtype.type is t1
+        else:
+            assert arr1.dtype.type is t2
 
     @pytest.mark.parametrize('t1', int_types + uint_types)
     @pytest.mark.parametrize('t2', int_types + uint_types + [None])

--- a/torch_np/tests/numpy_tests/core/test_scalar_methods.py
+++ b/torch_np/tests/numpy_tests/core/test_scalar_methods.py
@@ -1,0 +1,212 @@
+"""
+Test the scalar constructors, which also do type-coercion
+"""
+import sys
+import fractions
+import platform
+import types
+from typing import Any, Type
+
+import pytest
+import numpy as np
+
+from numpy.testing import assert_equal, assert_raises
+
+
+class TestAsIntegerRatio:
+    # derived in part from the cpython test "test_floatasratio"
+
+    @pytest.mark.parametrize("ftype", [
+        np.half, np.single, np.double, np.longdouble])
+    @pytest.mark.parametrize("f, ratio", [
+        (0.875, (7, 8)),
+        (-0.875, (-7, 8)),
+        (0.0, (0, 1)),
+        (11.5, (23, 2)),
+        ])
+    def test_small(self, ftype, f, ratio):
+        assert_equal(ftype(f).as_integer_ratio(), ratio)
+
+    @pytest.mark.parametrize("ftype", [
+        np.half, np.single, np.double, np.longdouble])
+    def test_simple_fractions(self, ftype):
+        R = fractions.Fraction
+        assert_equal(R(0, 1),
+                     R(*ftype(0.0).as_integer_ratio()))
+        assert_equal(R(5, 2),
+                     R(*ftype(2.5).as_integer_ratio()))
+        assert_equal(R(1, 2),
+                     R(*ftype(0.5).as_integer_ratio()))
+        assert_equal(R(-2100, 1),
+                     R(*ftype(-2100.0).as_integer_ratio()))
+
+    @pytest.mark.parametrize("ftype", [
+        np.half, np.single, np.double, np.longdouble])
+    def test_errors(self, ftype):
+        assert_raises(OverflowError, ftype('inf').as_integer_ratio)
+        assert_raises(OverflowError, ftype('-inf').as_integer_ratio)
+        assert_raises(ValueError, ftype('nan').as_integer_ratio)
+
+    def test_against_known_values(self):
+        R = fractions.Fraction
+        assert_equal(R(1075, 512),
+                     R(*np.half(2.1).as_integer_ratio()))
+        assert_equal(R(-1075, 512),
+                     R(*np.half(-2.1).as_integer_ratio()))
+        assert_equal(R(4404019, 2097152),
+                     R(*np.single(2.1).as_integer_ratio()))
+        assert_equal(R(-4404019, 2097152),
+                     R(*np.single(-2.1).as_integer_ratio()))
+        assert_equal(R(4728779608739021, 2251799813685248),
+                     R(*np.double(2.1).as_integer_ratio()))
+        assert_equal(R(-4728779608739021, 2251799813685248),
+                     R(*np.double(-2.1).as_integer_ratio()))
+        # longdouble is platform dependent
+
+    @pytest.mark.parametrize("ftype, frac_vals, exp_vals", [
+        # dtype test cases generated using hypothesis
+        # first five generated cases per dtype
+        (np.half, [0.0, 0.01154830649280303, 0.31082276347447274,
+                   0.527350517124794, 0.8308562335072596],
+                  [0, 1, 0, -8, 12]),
+        (np.single, [0.0, 0.09248576989263226, 0.8160498218131407,
+                     0.17389442853722373, 0.7956044195067877],
+                    [0, 12, 10, 17, -26]),
+        (np.double, [0.0, 0.031066908499895136, 0.5214135908877832,
+                     0.45780736035689296, 0.5906586745934036],
+                    [0, -801, 51, 194, -653]),
+        pytest.param(
+            np.longdouble,
+            [0.0, 0.20492557202724854, 0.4277180662199366, 0.9888085019891495,
+             0.9620175814461964],
+            [0, -7400, 14266, -7822, -8721],
+            marks=[
+                pytest.mark.skipif(
+                    np.finfo(np.double) == np.finfo(np.longdouble),
+                    reason="long double is same as double"),
+                pytest.mark.skipif(
+                    platform.machine().startswith("ppc"),
+                    reason="IBM double double"),
+            ]
+        )
+    ])
+    def test_roundtrip(self, ftype, frac_vals, exp_vals):
+        for frac, exp in zip(frac_vals, exp_vals):
+            f = np.ldexp(ftype(frac), exp)
+            assert f.dtype == ftype
+            n, d = f.as_integer_ratio()
+
+            try:
+                nf = np.longdouble(n)
+                df = np.longdouble(d)
+            except (OverflowError, RuntimeWarning):
+                # the values may not fit in any float type
+                pytest.skip("longdouble too small on this platform")
+
+            assert_equal(nf / df, f, "{}/{}".format(n, d))
+
+
+class TestIsInteger:
+    @pytest.mark.parametrize("str_value", ["inf", "nan"])
+    @pytest.mark.parametrize("code", np.typecodes["Float"])
+    def test_special(self, code: str, str_value: str) -> None:
+        cls = np.dtype(code).type
+        value = cls(str_value)
+        assert not value.is_integer()
+
+    @pytest.mark.parametrize(
+        "code", np.typecodes["Float"] + np.typecodes["AllInteger"]
+    )
+    def test_true(self, code: str) -> None:
+        float_array = np.arange(-5, 5).astype(code)
+        for value in float_array:
+            assert value.is_integer()
+
+    @pytest.mark.parametrize("code", np.typecodes["Float"])
+    def test_false(self, code: str) -> None:
+        float_array = np.arange(-5, 5).astype(code)
+        float_array *= 1.1
+        for value in float_array:
+            if value == 0:
+                continue
+            assert not value.is_integer()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
+class TestClassGetItem:
+    @pytest.mark.parametrize("cls", [
+        np.number,
+        np.integer,
+        np.inexact,
+        np.unsignedinteger,
+        np.signedinteger,
+        np.floating,
+    ])
+    def test_abc(self, cls: Type[np.number]) -> None:
+        alias = cls[Any]
+        assert isinstance(alias, types.GenericAlias)
+        assert alias.__origin__ is cls
+
+    def test_abc_complexfloating(self) -> None:
+        alias = np.complexfloating[Any, Any]
+        assert isinstance(alias, types.GenericAlias)
+        assert alias.__origin__ is np.complexfloating
+
+    @pytest.mark.parametrize("arg_len", range(4))
+    def test_abc_complexfloating_subscript_tuple(self, arg_len: int) -> None:
+        arg_tup = (Any,) * arg_len
+        if arg_len in (1, 2):
+            assert np.complexfloating[arg_tup]
+        else:
+            match = f"Too {'few' if arg_len == 0 else 'many'} arguments"
+            with pytest.raises(TypeError, match=match):
+                np.complexfloating[arg_tup]
+
+    @pytest.mark.parametrize("cls", [np.generic, np.flexible, np.character])
+    def test_abc_non_numeric(self, cls: Type[np.generic]) -> None:
+        with pytest.raises(TypeError):
+            cls[Any]
+
+    @pytest.mark.parametrize("code", np.typecodes["All"])
+    def test_concrete(self, code: str) -> None:
+        cls = np.dtype(code).type
+        with pytest.raises(TypeError):
+            cls[Any]
+
+    @pytest.mark.parametrize("arg_len", range(4))
+    def test_subscript_tuple(self, arg_len: int) -> None:
+        arg_tup = (Any,) * arg_len
+        if arg_len == 1:
+            assert np.number[arg_tup]
+        else:
+            with pytest.raises(TypeError):
+                np.number[arg_tup]
+
+    def test_subscript_scalar(self) -> None:
+        assert np.number[Any]
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Requires python 3.8")
+@pytest.mark.parametrize("cls", [np.number, np.complexfloating, np.int64])
+def test_class_getitem_38(cls: Type[np.number]) -> None:
+    match = "Type subscription requires python >= 3.9"
+    with pytest.raises(TypeError, match=match):
+        cls[Any]
+
+
+class TestBitCount:
+    # derived in part from the cpython test "test_bit_count"
+
+    @pytest.mark.parametrize("itype", np.sctypes['int']+np.sctypes['uint'])
+    def test_small(self, itype):
+        for a in range(max(np.iinfo(itype).min, 0), 128):
+            msg = f"Smoke test for {itype}({a}).bit_count()"
+            assert itype(a).bit_count() == bin(a).count("1"), msg
+
+    def test_bit_count(self):
+        for exp in [10, 17, 63]:
+            a = 2**exp
+            assert np.uint64(a).bit_count() == 1
+            assert np.uint64(a - 1).bit_count() == exp
+            assert np.uint64(a ^ 63).bit_count() == 7
+            assert np.uint64((a - 1) ^ 510).bit_count() == exp - 8

--- a/torch_np/tests/numpy_tests/core/test_scalar_methods.py
+++ b/torch_np/tests/numpy_tests/core/test_scalar_methods.py
@@ -17,11 +17,12 @@ from torch_np.testing import assert_equal
 from pytest import raises as assert_raises
 
 
+@pytest.mark.skip(reason='XXX: scalar.as_integer_ratio not implemented')
 class TestAsIntegerRatio:
     # derived in part from the cpython test "test_floatasratio"
 
     @pytest.mark.parametrize("ftype", [
-        np.half, np.single, np.double, np.longdouble])
+        np.half, np.single, np.double])
     @pytest.mark.parametrize("f, ratio", [
         (0.875, (7, 8)),
         (-0.875, (-7, 8)),
@@ -79,20 +80,6 @@ class TestAsIntegerRatio:
         (np.double, [0.0, 0.031066908499895136, 0.5214135908877832,
                      0.45780736035689296, 0.5906586745934036],
                     [0, -801, 51, 194, -653]),
-        pytest.param(
-            np.longdouble,
-            [0.0, 0.20492557202724854, 0.4277180662199366, 0.9888085019891495,
-             0.9620175814461964],
-            [0, -7400, 14266, -7822, -8721],
-            marks=[
-                pytest.mark.skipif(
-                    np.finfo(np.double) == np.finfo(np.longdouble),
-                    reason="long double is same as double"),
-                pytest.mark.skipif(
-                    platform.machine().startswith("ppc"),
-                    reason="IBM double double"),
-            ]
-        )
     ])
     def test_roundtrip(self, ftype, frac_vals, exp_vals):
         for frac, exp in zip(frac_vals, exp_vals):
@@ -136,6 +123,7 @@ class TestIsInteger:
             assert not value.is_integer()
 
 
+@pytest.mark.skip(reason='XXX: implementation details of the type system differ')
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires python 3.9")
 class TestClassGetItem:
     @pytest.mark.parametrize("cls", [
@@ -166,7 +154,7 @@ class TestClassGetItem:
             with pytest.raises(TypeError, match=match):
                 np.complexfloating[arg_tup]
 
-    @pytest.mark.parametrize("cls", [np.generic, np.flexible, np.character])
+    @pytest.mark.parametrize("cls", [np.generic])
     def test_abc_non_numeric(self, cls: Type[np.generic]) -> None:
         with pytest.raises(TypeError):
             cls[Any]
@@ -198,6 +186,7 @@ def test_class_getitem_38(cls: Type[np.number]) -> None:
         cls[Any]
 
 
+@pytest.mark.skip(reason="scalartype(...).bit_count() not implemented")
 class TestBitCount:
     # derived in part from the cpython test "test_bit_count"
 

--- a/torch_np/tests/numpy_tests/core/test_scalar_methods.py
+++ b/torch_np/tests/numpy_tests/core/test_scalar_methods.py
@@ -8,9 +8,13 @@ import types
 from typing import Any, Type
 
 import pytest
-import numpy as np
+#import numpy as np
 
-from numpy.testing import assert_equal, assert_raises
+#from numpy.testing import assert_equal, assert_raises
+
+import torch_np as np
+from torch_np.testing import assert_equal
+from pytest import raises as assert_raises
 
 
 class TestAsIntegerRatio:
@@ -28,7 +32,7 @@ class TestAsIntegerRatio:
         assert_equal(ftype(f).as_integer_ratio(), ratio)
 
     @pytest.mark.parametrize("ftype", [
-        np.half, np.single, np.double, np.longdouble])
+        np.half, np.single, np.double])
     def test_simple_fractions(self, ftype):
         R = fractions.Fraction
         assert_equal(R(0, 1),
@@ -41,7 +45,7 @@ class TestAsIntegerRatio:
                      R(*ftype(-2100.0).as_integer_ratio()))
 
     @pytest.mark.parametrize("ftype", [
-        np.half, np.single, np.double, np.longdouble])
+        np.half, np.single, np.double])
     def test_errors(self, ftype):
         assert_raises(OverflowError, ftype('inf').as_integer_ratio)
         assert_raises(OverflowError, ftype('-inf').as_integer_ratio)

--- a/torch_np/tests/numpy_tests/core/test_scalarinherit.py
+++ b/torch_np/tests/numpy_tests/core/test_scalarinherit.py
@@ -1,0 +1,98 @@
+""" Test printing of scalar types.
+
+"""
+import pytest
+
+import numpy as np
+from numpy.testing import assert_, assert_raises
+
+
+class A:
+    pass
+class B(A, np.float64):
+    pass
+
+class C(B):
+    pass
+class D(C, B):
+    pass
+
+class B0(np.float64, A):
+    pass
+class C0(B0):
+    pass
+
+class HasNew:
+    def __new__(cls, *args, **kwargs):
+        return cls, args, kwargs
+
+class B1(np.float64, HasNew):
+    pass
+
+
+class TestInherit:
+    def test_init(self):
+        x = B(1.0)
+        assert_(str(x) == '1.0')
+        y = C(2.0)
+        assert_(str(y) == '2.0')
+        z = D(3.0)
+        assert_(str(z) == '3.0')
+
+    def test_init2(self):
+        x = B0(1.0)
+        assert_(str(x) == '1.0')
+        y = C0(2.0)
+        assert_(str(y) == '2.0')
+
+    def test_gh_15395(self):
+        # HasNew is the second base, so `np.float64` should have priority
+        x = B1(1.0)
+        assert_(str(x) == '1.0')
+
+        # previously caused RecursionError!?
+        with pytest.raises(TypeError):
+            B1(1.0, 2.0)
+
+
+class TestCharacter:
+    def test_char_radd(self):
+        # GH issue 9620, reached gentype_add and raise TypeError
+        np_s = np.string_('abc')
+        np_u = np.unicode_('abc')
+        s = b'def'
+        u = 'def'
+        assert_(np_s.__radd__(np_s) is NotImplemented)
+        assert_(np_s.__radd__(np_u) is NotImplemented)
+        assert_(np_s.__radd__(s) is NotImplemented)
+        assert_(np_s.__radd__(u) is NotImplemented)
+        assert_(np_u.__radd__(np_s) is NotImplemented)
+        assert_(np_u.__radd__(np_u) is NotImplemented)
+        assert_(np_u.__radd__(s) is NotImplemented)
+        assert_(np_u.__radd__(u) is NotImplemented)
+        assert_(s + np_s == b'defabc')
+        assert_(u + np_u == 'defabc')
+
+        class MyStr(str, np.generic):
+            # would segfault
+            pass
+
+        with assert_raises(TypeError):
+            # Previously worked, but gave completely wrong result
+            ret = s + MyStr('abc')
+
+        class MyBytes(bytes, np.generic):
+            # would segfault
+            pass
+
+        ret = s + MyBytes(b'abc')
+        assert(type(ret) is type(s))
+        assert ret == b"defabc"
+
+    def test_char_repeat(self):
+        np_s = np.string_('abc')
+        np_u = np.unicode_('abc')
+        res_s = b'abc' * 5
+        res_u = 'abc' * 5
+        assert_(np_s * 5 == res_s)
+        assert_(np_u * 5 == res_u)

--- a/torch_np/tests/numpy_tests/core/test_scalarinherit.py
+++ b/torch_np/tests/numpy_tests/core/test_scalarinherit.py
@@ -3,8 +3,9 @@
 """
 import pytest
 
-import numpy as np
-from numpy.testing import assert_, assert_raises
+import torch_np as np
+from torch_np.testing import assert_
+from pytest import raises as assert_raises
 
 
 class A:
@@ -30,6 +31,7 @@ class B1(np.float64, HasNew):
     pass
 
 
+@pytest.mark.xfail(reason='scalar repr: numpy plain to make more explicit')
 class TestInherit:
     def test_init(self):
         x = B(1.0)
@@ -54,45 +56,3 @@ class TestInherit:
         with pytest.raises(TypeError):
             B1(1.0, 2.0)
 
-
-class TestCharacter:
-    def test_char_radd(self):
-        # GH issue 9620, reached gentype_add and raise TypeError
-        np_s = np.string_('abc')
-        np_u = np.unicode_('abc')
-        s = b'def'
-        u = 'def'
-        assert_(np_s.__radd__(np_s) is NotImplemented)
-        assert_(np_s.__radd__(np_u) is NotImplemented)
-        assert_(np_s.__radd__(s) is NotImplemented)
-        assert_(np_s.__radd__(u) is NotImplemented)
-        assert_(np_u.__radd__(np_s) is NotImplemented)
-        assert_(np_u.__radd__(np_u) is NotImplemented)
-        assert_(np_u.__radd__(s) is NotImplemented)
-        assert_(np_u.__radd__(u) is NotImplemented)
-        assert_(s + np_s == b'defabc')
-        assert_(u + np_u == 'defabc')
-
-        class MyStr(str, np.generic):
-            # would segfault
-            pass
-
-        with assert_raises(TypeError):
-            # Previously worked, but gave completely wrong result
-            ret = s + MyStr('abc')
-
-        class MyBytes(bytes, np.generic):
-            # would segfault
-            pass
-
-        ret = s + MyBytes(b'abc')
-        assert(type(ret) is type(s))
-        assert ret == b"defabc"
-
-    def test_char_repeat(self):
-        np_s = np.string_('abc')
-        np_u = np.unicode_('abc')
-        res_s = b'abc' * 5
-        res_u = 'abc' * 5
-        assert_(np_s * 5 == res_s)
-        assert_(np_u * 5 == res_u)

--- a/torch_np/tests/numpy_tests/core/test_scalarmath.py
+++ b/torch_np/tests/numpy_tests/core/test_scalarmath.py
@@ -1,0 +1,1052 @@
+import contextlib
+import sys
+import warnings
+import itertools
+import operator
+import platform
+from numpy._utils import _pep440
+import pytest
+from hypothesis import given, settings
+from hypothesis.strategies import sampled_from
+from hypothesis.extra import numpy as hynp
+
+import numpy as np
+from numpy.testing import (
+    assert_, assert_equal, assert_raises, assert_almost_equal,
+    assert_array_equal, IS_PYPY, suppress_warnings, _gen_alignment_data,
+    assert_warns,
+    )
+
+types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
+         np.int_, np.uint, np.longlong, np.ulonglong,
+         np.single, np.double, np.longdouble, np.csingle,
+         np.cdouble, np.clongdouble]
+
+floating_types = np.floating.__subclasses__()
+complex_floating_types = np.complexfloating.__subclasses__()
+
+objecty_things = [object(), None]
+
+reasonable_operators_for_scalars = [
+    operator.lt, operator.le, operator.eq, operator.ne, operator.ge,
+    operator.gt, operator.add, operator.floordiv, operator.mod,
+    operator.mul, operator.pow, operator.sub, operator.truediv,
+]
+
+
+# This compares scalarmath against ufuncs.
+
+class TestTypes:
+    def test_types(self):
+        for atype in types:
+            a = atype(1)
+            assert_(a == 1, "error with %r: got %r" % (atype, a))
+
+    def test_type_add(self):
+        # list of types
+        for k, atype in enumerate(types):
+            a_scalar = atype(3)
+            a_array = np.array([3], dtype=atype)
+            for l, btype in enumerate(types):
+                b_scalar = btype(1)
+                b_array = np.array([1], dtype=btype)
+                c_scalar = a_scalar + b_scalar
+                c_array = a_array + b_array
+                # It was comparing the type numbers, but the new ufunc
+                # function-finding mechanism finds the lowest function
+                # to which both inputs can be cast - which produces 'l'
+                # when you do 'q' + 'b'.  The old function finding mechanism
+                # skipped ahead based on the first argument, but that
+                # does not produce properly symmetric results...
+                assert_equal(c_scalar.dtype, c_array.dtype,
+                           "error with types (%d/'%c' + %d/'%c')" %
+                            (k, np.dtype(atype).char, l, np.dtype(btype).char))
+
+    def test_type_create(self):
+        for k, atype in enumerate(types):
+            a = np.array([1, 2, 3], atype)
+            b = atype([1, 2, 3])
+            assert_equal(a, b)
+
+    def test_leak(self):
+        # test leak of scalar objects
+        # a leak would show up in valgrind as still-reachable of ~2.6MB
+        for i in range(200000):
+            np.add(1, 1)
+
+
+@pytest.mark.slow
+@settings(max_examples=10000, deadline=2000)
+@given(sampled_from(reasonable_operators_for_scalars),
+       hynp.arrays(dtype=hynp.scalar_dtypes(), shape=()),
+       hynp.arrays(dtype=hynp.scalar_dtypes(), shape=()))
+def test_array_scalar_ufunc_equivalence(op, arr1, arr2):
+    """
+    This is a thorough test attempting to cover important promotion paths
+    and ensuring that arrays and scalars stay as aligned as possible.
+    However, if it creates troubles, it should maybe just be removed.
+    """
+    scalar1 = arr1[()]
+    scalar2 = arr2[()]
+    assert isinstance(scalar1, np.generic)
+    assert isinstance(scalar2, np.generic)
+
+    if arr1.dtype.kind == "c" or arr2.dtype.kind == "c":
+        comp_ops = {operator.ge, operator.gt, operator.le, operator.lt}
+        if op in comp_ops and (np.isnan(scalar1) or np.isnan(scalar2)):
+            pytest.xfail("complex comp ufuncs use sort-order, scalars do not.")
+
+    # ignore fpe's since they may just mismatch for integers anyway.
+    with warnings.catch_warnings(), np.errstate(all="ignore"):
+        # Comparisons DeprecationWarnings replacing errors (2022-03):
+        warnings.simplefilter("error", DeprecationWarning)
+        try:
+            res = op(arr1, arr2)
+        except Exception as e:
+            with pytest.raises(type(e)):
+                op(scalar1, scalar2)
+        else:
+            scalar_res = op(scalar1, scalar2)
+            assert_array_equal(scalar_res, res)
+
+
+class TestBaseMath:
+    def test_blocked(self):
+        # test alignments offsets for simd instructions
+        # alignments for vz + 2 * (vs - 1) + 1
+        for dt, sz in [(np.float32, 11), (np.float64, 7), (np.int32, 11)]:
+            for out, inp1, inp2, msg in _gen_alignment_data(dtype=dt,
+                                                            type='binary',
+                                                            max_size=sz):
+                exp1 = np.ones_like(inp1)
+                inp1[...] = np.ones_like(inp1)
+                inp2[...] = np.zeros_like(inp2)
+                assert_almost_equal(np.add(inp1, inp2), exp1, err_msg=msg)
+                assert_almost_equal(np.add(inp1, 2), exp1 + 2, err_msg=msg)
+                assert_almost_equal(np.add(1, inp2), exp1, err_msg=msg)
+
+                np.add(inp1, inp2, out=out)
+                assert_almost_equal(out, exp1, err_msg=msg)
+
+                inp2[...] += np.arange(inp2.size, dtype=dt) + 1
+                assert_almost_equal(np.square(inp2),
+                                    np.multiply(inp2, inp2),  err_msg=msg)
+                # skip true divide for ints
+                if dt != np.int32:
+                    assert_almost_equal(np.reciprocal(inp2),
+                                        np.divide(1, inp2),  err_msg=msg)
+
+                inp1[...] = np.ones_like(inp1)
+                np.add(inp1, 2, out=out)
+                assert_almost_equal(out, exp1 + 2, err_msg=msg)
+                inp2[...] = np.ones_like(inp2)
+                np.add(2, inp2, out=out)
+                assert_almost_equal(out, exp1 + 2, err_msg=msg)
+
+    def test_lower_align(self):
+        # check data that is not aligned to element size
+        # i.e doubles are aligned to 4 bytes on i386
+        d = np.zeros(23 * 8, dtype=np.int8)[4:-4].view(np.float64)
+        o = np.zeros(23 * 8, dtype=np.int8)[4:-4].view(np.float64)
+        assert_almost_equal(d + d, d * 2)
+        np.add(d, d, out=o)
+        np.add(np.ones_like(d), d, out=o)
+        np.add(d, np.ones_like(d), out=o)
+        np.add(np.ones_like(d), d)
+        np.add(d, np.ones_like(d))
+
+
+class TestPower:
+    def test_small_types(self):
+        for t in [np.int8, np.int16, np.float16]:
+            a = t(3)
+            b = a ** 4
+            assert_(b == 81, "error with %r: got %r" % (t, b))
+
+    def test_large_types(self):
+        for t in [np.int32, np.int64, np.float32, np.float64, np.longdouble]:
+            a = t(51)
+            b = a ** 4
+            msg = "error with %r: got %r" % (t, b)
+            if np.issubdtype(t, np.integer):
+                assert_(b == 6765201, msg)
+            else:
+                assert_almost_equal(b, 6765201, err_msg=msg)
+
+    def test_integers_to_negative_integer_power(self):
+        # Note that the combination of uint64 with a signed integer
+        # has common type np.float64. The other combinations should all
+        # raise a ValueError for integer ** negative integer.
+        exp = [np.array(-1, dt)[()] for dt in 'bhilq']
+
+        # 1 ** -1 possible special case
+        base = [np.array(1, dt)[()] for dt in 'bhilqBHILQ']
+        for i1, i2 in itertools.product(base, exp):
+            if i1.dtype != np.uint64:
+                assert_raises(ValueError, operator.pow, i1, i2)
+            else:
+                res = operator.pow(i1, i2)
+                assert_(res.dtype.type is np.float64)
+                assert_almost_equal(res, 1.)
+
+        # -1 ** -1 possible special case
+        base = [np.array(-1, dt)[()] for dt in 'bhilq']
+        for i1, i2 in itertools.product(base, exp):
+            if i1.dtype != np.uint64:
+                assert_raises(ValueError, operator.pow, i1, i2)
+            else:
+                res = operator.pow(i1, i2)
+                assert_(res.dtype.type is np.float64)
+                assert_almost_equal(res, -1.)
+
+        # 2 ** -1 perhaps generic
+        base = [np.array(2, dt)[()] for dt in 'bhilqBHILQ']
+        for i1, i2 in itertools.product(base, exp):
+            if i1.dtype != np.uint64:
+                assert_raises(ValueError, operator.pow, i1, i2)
+            else:
+                res = operator.pow(i1, i2)
+                assert_(res.dtype.type is np.float64)
+                assert_almost_equal(res, .5)
+
+    def test_mixed_types(self):
+        typelist = [np.int8, np.int16, np.float16,
+                    np.float32, np.float64, np.int8,
+                    np.int16, np.int32, np.int64]
+        for t1 in typelist:
+            for t2 in typelist:
+                a = t1(3)
+                b = t2(2)
+                result = a**b
+                msg = ("error with %r and %r:"
+                       "got %r, expected %r") % (t1, t2, result, 9)
+                if np.issubdtype(np.dtype(result), np.integer):
+                    assert_(result == 9, msg)
+                else:
+                    assert_almost_equal(result, 9, err_msg=msg)
+
+    def test_modular_power(self):
+        # modular power is not implemented, so ensure it errors
+        a = 5
+        b = 4
+        c = 10
+        expected = pow(a, b, c)  # noqa: F841
+        for t in (np.int32, np.float32, np.complex64):
+            # note that 3-operand power only dispatches on the first argument
+            assert_raises(TypeError, operator.pow, t(a), b, c)
+            assert_raises(TypeError, operator.pow, np.array(t(a)), b, c)
+
+
+def floordiv_and_mod(x, y):
+    return (x // y, x % y)
+
+
+def _signs(dt):
+    if dt in np.typecodes['UnsignedInteger']:
+        return (+1,)
+    else:
+        return (+1, -1)
+
+
+class TestModulus:
+
+    def test_modulus_basic(self):
+        dt = np.typecodes['AllInteger'] + np.typecodes['Float']
+        for op in [floordiv_and_mod, divmod]:
+            for dt1, dt2 in itertools.product(dt, dt):
+                for sg1, sg2 in itertools.product(_signs(dt1), _signs(dt2)):
+                    fmt = 'op: %s, dt1: %s, dt2: %s, sg1: %s, sg2: %s'
+                    msg = fmt % (op.__name__, dt1, dt2, sg1, sg2)
+                    a = np.array(sg1*71, dtype=dt1)[()]
+                    b = np.array(sg2*19, dtype=dt2)[()]
+                    div, rem = op(a, b)
+                    assert_equal(div*b + rem, a, err_msg=msg)
+                    if sg2 == -1:
+                        assert_(b < rem <= 0, msg)
+                    else:
+                        assert_(b > rem >= 0, msg)
+
+    def test_float_modulus_exact(self):
+        # test that float results are exact for small integers. This also
+        # holds for the same integers scaled by powers of two.
+        nlst = list(range(-127, 0))
+        plst = list(range(1, 128))
+        dividend = nlst + [0] + plst
+        divisor = nlst + plst
+        arg = list(itertools.product(dividend, divisor))
+        tgt = list(divmod(*t) for t in arg)
+
+        a, b = np.array(arg, dtype=int).T
+        # convert exact integer results from Python to float so that
+        # signed zero can be used, it is checked.
+        tgtdiv, tgtrem = np.array(tgt, dtype=float).T
+        tgtdiv = np.where((tgtdiv == 0.0) & ((b < 0) ^ (a < 0)), -0.0, tgtdiv)
+        tgtrem = np.where((tgtrem == 0.0) & (b < 0), -0.0, tgtrem)
+
+        for op in [floordiv_and_mod, divmod]:
+            for dt in np.typecodes['Float']:
+                msg = 'op: %s, dtype: %s' % (op.__name__, dt)
+                fa = a.astype(dt)
+                fb = b.astype(dt)
+                # use list comprehension so a_ and b_ are scalars
+                div, rem = zip(*[op(a_, b_) for  a_, b_ in zip(fa, fb)])
+                assert_equal(div, tgtdiv, err_msg=msg)
+                assert_equal(rem, tgtrem, err_msg=msg)
+
+    def test_float_modulus_roundoff(self):
+        # gh-6127
+        dt = np.typecodes['Float']
+        for op in [floordiv_and_mod, divmod]:
+            for dt1, dt2 in itertools.product(dt, dt):
+                for sg1, sg2 in itertools.product((+1, -1), (+1, -1)):
+                    fmt = 'op: %s, dt1: %s, dt2: %s, sg1: %s, sg2: %s'
+                    msg = fmt % (op.__name__, dt1, dt2, sg1, sg2)
+                    a = np.array(sg1*78*6e-8, dtype=dt1)[()]
+                    b = np.array(sg2*6e-8, dtype=dt2)[()]
+                    div, rem = op(a, b)
+                    # Equal assertion should hold when fmod is used
+                    assert_equal(div*b + rem, a, err_msg=msg)
+                    if sg2 == -1:
+                        assert_(b < rem <= 0, msg)
+                    else:
+                        assert_(b > rem >= 0, msg)
+
+    def test_float_modulus_corner_cases(self):
+        # Check remainder magnitude.
+        for dt in np.typecodes['Float']:
+            b = np.array(1.0, dtype=dt)
+            a = np.nextafter(np.array(0.0, dtype=dt), -b)
+            rem = operator.mod(a, b)
+            assert_(rem <= b, 'dt: %s' % dt)
+            rem = operator.mod(-a, -b)
+            assert_(rem >= -b, 'dt: %s' % dt)
+
+        # Check nans, inf
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "invalid value encountered in remainder")
+            sup.filter(RuntimeWarning, "divide by zero encountered in remainder")
+            sup.filter(RuntimeWarning, "divide by zero encountered in floor_divide")
+            sup.filter(RuntimeWarning, "divide by zero encountered in divmod")
+            sup.filter(RuntimeWarning, "invalid value encountered in divmod")
+            for dt in np.typecodes['Float']:
+                fone = np.array(1.0, dtype=dt)
+                fzer = np.array(0.0, dtype=dt)
+                finf = np.array(np.inf, dtype=dt)
+                fnan = np.array(np.nan, dtype=dt)
+                rem = operator.mod(fone, fzer)
+                assert_(np.isnan(rem), 'dt: %s' % dt)
+                # MSVC 2008 returns NaN here, so disable the check.
+                #rem = operator.mod(fone, finf)
+                #assert_(rem == fone, 'dt: %s' % dt)
+                rem = operator.mod(fone, fnan)
+                assert_(np.isnan(rem), 'dt: %s' % dt)
+                rem = operator.mod(finf, fone)
+                assert_(np.isnan(rem), 'dt: %s' % dt)
+                for op in [floordiv_and_mod, divmod]:
+                    div, mod = op(fone, fzer)
+                    assert_(np.isinf(div)) and assert_(np.isnan(mod))
+
+    def test_inplace_floordiv_handling(self):
+        # issue gh-12927
+        # this only applies to in-place floordiv //=, because the output type
+        # promotes to float which does not fit
+        a = np.array([1, 2], np.int64)
+        b = np.array([1, 2], np.uint64)
+        with pytest.raises(TypeError,
+                match=r"Cannot cast ufunc 'floor_divide' output from"):
+            a //= b
+
+
+class TestComplexDivision:
+    def test_zero_division(self):
+        with np.errstate(all="ignore"):
+            for t in [np.complex64, np.complex128]:
+                a = t(0.0)
+                b = t(1.0)
+                assert_(np.isinf(b/a))
+                b = t(complex(np.inf, np.inf))
+                assert_(np.isinf(b/a))
+                b = t(complex(np.inf, np.nan))
+                assert_(np.isinf(b/a))
+                b = t(complex(np.nan, np.inf))
+                assert_(np.isinf(b/a))
+                b = t(complex(np.nan, np.nan))
+                assert_(np.isnan(b/a))
+                b = t(0.)
+                assert_(np.isnan(b/a))
+
+    def test_signed_zeros(self):
+        with np.errstate(all="ignore"):
+            for t in [np.complex64, np.complex128]:
+                # tupled (numerator, denominator, expected)
+                # for testing as expected == numerator/denominator
+                data = (
+                    (( 0.0,-1.0), ( 0.0, 1.0), (-1.0,-0.0)),
+                    (( 0.0,-1.0), ( 0.0,-1.0), ( 1.0,-0.0)),
+                    (( 0.0,-1.0), (-0.0,-1.0), ( 1.0, 0.0)),
+                    (( 0.0,-1.0), (-0.0, 1.0), (-1.0, 0.0)),
+                    (( 0.0, 1.0), ( 0.0,-1.0), (-1.0, 0.0)),
+                    (( 0.0,-1.0), ( 0.0,-1.0), ( 1.0,-0.0)),
+                    ((-0.0,-1.0), ( 0.0,-1.0), ( 1.0,-0.0)),
+                    ((-0.0, 1.0), ( 0.0,-1.0), (-1.0,-0.0))
+                )
+                for cases in data:
+                    n = cases[0]
+                    d = cases[1]
+                    ex = cases[2]
+                    result = t(complex(n[0], n[1])) / t(complex(d[0], d[1]))
+                    # check real and imag parts separately to avoid comparison
+                    # in array context, which does not account for signed zeros
+                    assert_equal(result.real, ex[0])
+                    assert_equal(result.imag, ex[1])
+
+    def test_branches(self):
+        with np.errstate(all="ignore"):
+            for t in [np.complex64, np.complex128]:
+                # tupled (numerator, denominator, expected)
+                # for testing as expected == numerator/denominator
+                data = list()
+
+                # trigger branch: real(fabs(denom)) > imag(fabs(denom))
+                # followed by else condition as neither are == 0
+                data.append((( 2.0, 1.0), ( 2.0, 1.0), (1.0, 0.0)))
+
+                # trigger branch: real(fabs(denom)) > imag(fabs(denom))
+                # followed by if condition as both are == 0
+                # is performed in test_zero_division(), so this is skipped
+
+                # trigger else if branch: real(fabs(denom)) < imag(fabs(denom))
+                data.append((( 1.0, 2.0), ( 1.0, 2.0), (1.0, 0.0)))
+
+                for cases in data:
+                    n = cases[0]
+                    d = cases[1]
+                    ex = cases[2]
+                    result = t(complex(n[0], n[1])) / t(complex(d[0], d[1]))
+                    # check real and imag parts separately to avoid comparison
+                    # in array context, which does not account for signed zeros
+                    assert_equal(result.real, ex[0])
+                    assert_equal(result.imag, ex[1])
+
+
+class TestConversion:
+    def test_int_from_long(self):
+        l = [1e6, 1e12, 1e18, -1e6, -1e12, -1e18]
+        li = [10**6, 10**12, 10**18, -10**6, -10**12, -10**18]
+        for T in [None, np.float64, np.int64]:
+            a = np.array(l, dtype=T)
+            assert_equal([int(_m) for _m in a], li)
+
+        a = np.array(l[:3], dtype=np.uint64)
+        assert_equal([int(_m) for _m in a], li[:3])
+
+    def test_iinfo_long_values(self):
+        for code in 'bBhH':
+            with pytest.warns(DeprecationWarning):
+                res = np.array(np.iinfo(code).max + 1, dtype=code)
+            tgt = np.iinfo(code).min
+            assert_(res == tgt)
+
+        for code in np.typecodes['AllInteger']:
+            res = np.array(np.iinfo(code).max, dtype=code)
+            tgt = np.iinfo(code).max
+            assert_(res == tgt)
+
+        for code in np.typecodes['AllInteger']:
+            res = np.dtype(code).type(np.iinfo(code).max)
+            tgt = np.iinfo(code).max
+            assert_(res == tgt)
+
+    def test_int_raise_behaviour(self):
+        def overflow_error_func(dtype):
+            dtype(np.iinfo(dtype).max + 1)
+
+        for code in [np.int_, np.uint, np.longlong, np.ulonglong]:
+            assert_raises(OverflowError, overflow_error_func, code)
+
+    def test_int_from_infinite_longdouble(self):
+        # gh-627
+        x = np.longdouble(np.inf)
+        assert_raises(OverflowError, int, x)
+        with suppress_warnings() as sup:
+            sup.record(np.ComplexWarning)
+            x = np.clongdouble(np.inf)
+            assert_raises(OverflowError, int, x)
+            assert_equal(len(sup.log), 1)
+
+    @pytest.mark.skipif(not IS_PYPY, reason="Test is PyPy only (gh-9972)")
+    def test_int_from_infinite_longdouble___int__(self):
+        x = np.longdouble(np.inf)
+        assert_raises(OverflowError, x.__int__)
+        with suppress_warnings() as sup:
+            sup.record(np.ComplexWarning)
+            x = np.clongdouble(np.inf)
+            assert_raises(OverflowError, x.__int__)
+            assert_equal(len(sup.log), 1)
+
+    @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
+                        reason="long double is same as double")
+    @pytest.mark.skipif(platform.machine().startswith("ppc"),
+                        reason="IBM double double")
+    def test_int_from_huge_longdouble(self):
+        # Produce a longdouble that would overflow a double,
+        # use exponent that avoids bug in Darwin pow function.
+        exp = np.finfo(np.double).maxexp - 1
+        huge_ld = 2 * 1234 * np.longdouble(2) ** exp
+        huge_i = 2 * 1234 * 2 ** exp
+        assert_(huge_ld != np.inf)
+        assert_equal(int(huge_ld), huge_i)
+
+    def test_int_from_longdouble(self):
+        x = np.longdouble(1.5)
+        assert_equal(int(x), 1)
+        x = np.longdouble(-10.5)
+        assert_equal(int(x), -10)
+
+    def test_numpy_scalar_relational_operators(self):
+        # All integer
+        for dt1 in np.typecodes['AllInteger']:
+            assert_(1 > np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(0, dtype=dt1)[()], "type %s failed" % (dt1,))
+
+            for dt2 in np.typecodes['AllInteger']:
+                assert_(np.array(1, dtype=dt1)[()] > np.array(0, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(0, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+
+        #Unsigned integers
+        for dt1 in 'BHILQP':
+            assert_(-1 < np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not -1 > np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(-1 != np.array(1, dtype=dt1)[()], "type %s failed" % (dt1,))
+
+            #unsigned vs signed
+            for dt2 in 'bhilqp':
+                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(1, dtype=dt1)[()] != np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+
+        #Signed integers and floats
+        for dt1 in 'bhlqp' + np.typecodes['Float']:
+            assert_(1 > np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(not 1 < np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+            assert_(-1 == np.array(-1, dtype=dt1)[()], "type %s failed" % (dt1,))
+
+            for dt2 in 'bhlqp' + np.typecodes['Float']:
+                assert_(np.array(1, dtype=dt1)[()] > np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(not np.array(1, dtype=dt1)[()] < np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+                assert_(np.array(-1, dtype=dt1)[()] == np.array(-1, dtype=dt2)[()],
+                        "type %s and %s failed" % (dt1, dt2))
+
+    def test_scalar_comparison_to_none(self):
+        # Scalars should just return False and not give a warnings.
+        # The comparisons are flagged by pep8, ignore that.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', '', FutureWarning)
+            assert_(not np.float32(1) == None)
+            assert_(not np.str_('test') == None)
+            # This is dubious (see below):
+            assert_(not np.datetime64('NaT') == None)
+
+            assert_(np.float32(1) != None)
+            assert_(np.str_('test') != None)
+            # This is dubious (see below):
+            assert_(np.datetime64('NaT') != None)
+        assert_(len(w) == 0)
+
+        # For documentation purposes, this is why the datetime is dubious.
+        # At the time of deprecation this was no behaviour change, but
+        # it has to be considered when the deprecations are done.
+        assert_(np.equal(np.datetime64('NaT'), None))
+
+
+#class TestRepr:
+#    def test_repr(self):
+#        for t in types:
+#            val = t(1197346475.0137341)
+#            val_repr = repr(val)
+#            val2 = eval(val_repr)
+#            assert_equal( val, val2 )
+
+
+class TestRepr:
+    def _test_type_repr(self, t):
+        finfo = np.finfo(t)
+        last_fraction_bit_idx = finfo.nexp + finfo.nmant
+        last_exponent_bit_idx = finfo.nexp
+        storage_bytes = np.dtype(t).itemsize*8
+        # could add some more types to the list below
+        for which in ['small denorm', 'small norm']:
+            # Values from https://en.wikipedia.org/wiki/IEEE_754
+            constr = np.array([0x00]*storage_bytes, dtype=np.uint8)
+            if which == 'small denorm':
+                byte = last_fraction_bit_idx // 8
+                bytebit = 7-(last_fraction_bit_idx % 8)
+                constr[byte] = 1 << bytebit
+            elif which == 'small norm':
+                byte = last_exponent_bit_idx // 8
+                bytebit = 7-(last_exponent_bit_idx % 8)
+                constr[byte] = 1 << bytebit
+            else:
+                raise ValueError('hmm')
+            val = constr.view(t)[0]
+            val_repr = repr(val)
+            val2 = t(eval(val_repr))
+            if not (val2 == 0 and val < 1e-100):
+                assert_equal(val, val2)
+
+    def test_float_repr(self):
+        # long double test cannot work, because eval goes through a python
+        # float
+        for t in [np.float32, np.float64]:
+            self._test_type_repr(t)
+
+
+if not IS_PYPY:
+    # sys.getsizeof() is not valid on PyPy
+    class TestSizeOf:
+
+        def test_equal_nbytes(self):
+            for type in types:
+                x = type(0)
+                assert_(sys.getsizeof(x) > x.nbytes)
+
+        def test_error(self):
+            d = np.float32()
+            assert_raises(TypeError, d.__sizeof__, "a")
+
+
+class TestMultiply:
+    def test_seq_repeat(self):
+        # Test that basic sequences get repeated when multiplied with
+        # numpy integers. And errors are raised when multiplied with others.
+        # Some of this behaviour may be controversial and could be open for
+        # change.
+        accepted_types = set(np.typecodes["AllInteger"])
+        deprecated_types = {'?'}
+        forbidden_types = (
+            set(np.typecodes["All"]) - accepted_types - deprecated_types)
+        forbidden_types -= {'V'}  # can't default-construct void scalars
+
+        for seq_type in (list, tuple):
+            seq = seq_type([1, 2, 3])
+            for numpy_type in accepted_types:
+                i = np.dtype(numpy_type).type(2)
+                assert_equal(seq * i, seq * int(i))
+                assert_equal(i * seq, int(i) * seq)
+
+            for numpy_type in deprecated_types:
+                i = np.dtype(numpy_type).type()
+                assert_equal(
+                    assert_warns(DeprecationWarning, operator.mul, seq, i),
+                    seq * int(i))
+                assert_equal(
+                    assert_warns(DeprecationWarning, operator.mul, i, seq),
+                    int(i) * seq)
+
+            for numpy_type in forbidden_types:
+                i = np.dtype(numpy_type).type()
+                assert_raises(TypeError, operator.mul, seq, i)
+                assert_raises(TypeError, operator.mul, i, seq)
+
+    def test_no_seq_repeat_basic_array_like(self):
+        # Test that an array-like which does not know how to be multiplied
+        # does not attempt sequence repeat (raise TypeError).
+        # See also gh-7428.
+        class ArrayLike:
+            def __init__(self, arr):
+                self.arr = arr
+            def __array__(self):
+                return self.arr
+
+        # Test for simple ArrayLike above and memoryviews (original report)
+        for arr_like in (ArrayLike(np.ones(3)), memoryview(np.ones(3))):
+            assert_array_equal(arr_like * np.float32(3.), np.full(3, 3.))
+            assert_array_equal(np.float32(3.) * arr_like, np.full(3, 3.))
+            assert_array_equal(arr_like * np.int_(3), np.full(3, 3))
+            assert_array_equal(np.int_(3) * arr_like, np.full(3, 3))
+
+
+class TestNegative:
+    def test_exceptions(self):
+        a = np.ones((), dtype=np.bool_)[()]
+        assert_raises(TypeError, operator.neg, a)
+
+    def test_result(self):
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            for dt in types:
+                a = np.ones((), dtype=dt)[()]
+                if dt in np.typecodes['UnsignedInteger']:
+                    st = np.dtype(dt).type
+                    max = st(np.iinfo(dt).max)
+                    assert_equal(operator.neg(a), max)
+                else:
+                    assert_equal(operator.neg(a) + a, 0)
+
+class TestSubtract:
+    def test_exceptions(self):
+        a = np.ones((), dtype=np.bool_)[()]
+        assert_raises(TypeError, operator.sub, a, a)
+
+    def test_result(self):
+        types = np.typecodes['AllInteger'] + np.typecodes['AllFloat']
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            for dt in types:
+                a = np.ones((), dtype=dt)[()]
+                assert_equal(operator.sub(a, a), 0)
+
+
+class TestAbs:
+    def _test_abs_func(self, absfunc, test_dtype):
+        x = test_dtype(-1.5)
+        assert_equal(absfunc(x), 1.5)
+        x = test_dtype(0.0)
+        res = absfunc(x)
+        # assert_equal() checks zero signedness
+        assert_equal(res, 0.0)
+        x = test_dtype(-0.0)
+        res = absfunc(x)
+        assert_equal(res, 0.0)
+
+        x = test_dtype(np.finfo(test_dtype).max)
+        assert_equal(absfunc(x), x.real)
+
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning)
+            x = test_dtype(np.finfo(test_dtype).tiny)
+            assert_equal(absfunc(x), x.real)
+
+        x = test_dtype(np.finfo(test_dtype).min)
+        assert_equal(absfunc(x), -x.real)
+
+    @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
+    def test_builtin_abs(self, dtype):
+        if (
+                sys.platform == "cygwin" and dtype == np.clongdouble and
+                (
+                    _pep440.parse(platform.release().split("-")[0])
+                    < _pep440.Version("3.3.0")
+                )
+        ):
+            pytest.xfail(
+                reason="absl is computed in double precision on cygwin < 3.3"
+            )
+        self._test_abs_func(abs, dtype)
+
+    @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
+    def test_numpy_abs(self, dtype):
+        if (
+                sys.platform == "cygwin" and dtype == np.clongdouble and
+                (
+                    _pep440.parse(platform.release().split("-")[0])
+                    < _pep440.Version("3.3.0")
+                )
+        ):
+            pytest.xfail(
+                reason="absl is computed in double precision on cygwin < 3.3"
+            )
+        self._test_abs_func(np.abs, dtype)
+
+class TestBitShifts:
+
+    @pytest.mark.parametrize('type_code', np.typecodes['AllInteger'])
+    @pytest.mark.parametrize('op',
+        [operator.rshift, operator.lshift], ids=['>>', '<<'])
+    def test_shift_all_bits(self, type_code, op):
+        """ Shifts where the shift amount is the width of the type or wider """
+        # gh-2449
+        dt = np.dtype(type_code)
+        nbits = dt.itemsize * 8
+        for val in [5, -5]:
+            for shift in [nbits, nbits + 4]:
+                val_scl = np.array(val).astype(dt)[()]
+                shift_scl = dt.type(shift)
+                res_scl = op(val_scl, shift_scl)
+                if val_scl < 0 and op is operator.rshift:
+                    # sign bit is preserved
+                    assert_equal(res_scl, -1)
+                else:
+                    assert_equal(res_scl, 0)
+
+                # Result on scalars should be the same as on arrays
+                val_arr = np.array([val_scl]*32, dtype=dt)
+                shift_arr = np.array([shift]*32, dtype=dt)
+                res_arr = op(val_arr, shift_arr)
+                assert_equal(res_arr, res_scl)
+
+
+class TestHash:
+    @pytest.mark.parametrize("type_code", np.typecodes['AllInteger'])
+    def test_integer_hashes(self, type_code):
+        scalar = np.dtype(type_code).type
+        for i in range(128):
+            assert hash(i) == hash(scalar(i))
+
+    @pytest.mark.parametrize("type_code", np.typecodes['AllFloat'])
+    def test_float_and_complex_hashes(self, type_code):
+        scalar = np.dtype(type_code).type
+        for val in [np.pi, np.inf, 3, 6.]:
+            numpy_val = scalar(val)
+            # Cast back to Python, in case the NumPy scalar has less precision
+            if numpy_val.dtype.kind == 'c':
+                val = complex(numpy_val)
+            else:
+                val = float(numpy_val)
+            assert val == numpy_val
+            assert hash(val) == hash(numpy_val)
+
+        if hash(float(np.nan)) != hash(float(np.nan)):
+            # If Python distinguishes different NaNs we do so too (gh-18833)
+            assert hash(scalar(np.nan)) != hash(scalar(np.nan))
+
+    @pytest.mark.parametrize("type_code", np.typecodes['Complex'])
+    def test_complex_hashes(self, type_code):
+        # Test some complex valued hashes specifically:
+        scalar = np.dtype(type_code).type
+        for val in [np.pi+1j, np.inf-3j, 3j, 6.+1j]:
+            numpy_val = scalar(val)
+            assert hash(complex(numpy_val)) == hash(numpy_val)
+
+
+@contextlib.contextmanager
+def recursionlimit(n):
+    o = sys.getrecursionlimit()
+    try:
+        sys.setrecursionlimit(n)
+        yield
+    finally:
+        sys.setrecursionlimit(o)
+
+
+@given(sampled_from(objecty_things),
+       sampled_from(reasonable_operators_for_scalars),
+       sampled_from(types))
+def test_operator_object_left(o, op, type_):
+    try:
+        with recursionlimit(200):
+            op(o, type_(1))
+    except TypeError:
+        pass
+
+
+@given(sampled_from(objecty_things),
+       sampled_from(reasonable_operators_for_scalars),
+       sampled_from(types))
+def test_operator_object_right(o, op, type_):
+    try:
+        with recursionlimit(200):
+            op(type_(1), o)
+    except TypeError:
+        pass
+
+
+@given(sampled_from(reasonable_operators_for_scalars),
+       sampled_from(types),
+       sampled_from(types))
+def test_operator_scalars(op, type1, type2):
+    try:
+        op(type1(1), type2(1))
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("op", reasonable_operators_for_scalars)
+@pytest.mark.parametrize("val", [None, 2**64])
+def test_longdouble_inf_loop(op, val):
+    # Note: The 2**64 value will pass once NEP 50 is adopted.
+    try:
+        op(np.longdouble(3), val)
+    except TypeError:
+        pass
+    try:
+        op(val, np.longdouble(3))
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("op", reasonable_operators_for_scalars)
+@pytest.mark.parametrize("val", [None, 2**64])
+def test_clongdouble_inf_loop(op, val):
+    # Note: The 2**64 value will pass once NEP 50 is adopted.
+    try:
+        op(np.clongdouble(3), val)
+    except TypeError:
+        pass
+    try:
+        op(val, np.longdouble(3))
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
+@pytest.mark.parametrize("operation", [
+        lambda min, max: max + max,
+        lambda min, max: min - max,
+        lambda min, max: max * max], ids=["+", "-", "*"])
+def test_scalar_integer_operation_overflow(dtype, operation):
+    st = np.dtype(dtype).type
+    min = st(np.iinfo(dtype).min)
+    max = st(np.iinfo(dtype).max)
+
+    with pytest.warns(RuntimeWarning, match="overflow encountered"):
+        operation(min, max)
+
+
+@pytest.mark.parametrize("dtype", np.typecodes["Integer"])
+@pytest.mark.parametrize("operation", [
+        lambda min, neg_1: -min,
+        lambda min, neg_1: abs(min),
+        lambda min, neg_1: min * neg_1,
+        pytest.param(lambda min, neg_1: min // neg_1,
+            marks=pytest.mark.skip(reason="broken on some platforms"))],
+        ids=["neg", "abs", "*", "//"])
+def test_scalar_signed_integer_overflow(dtype, operation):
+    # The minimum signed integer can "overflow" for some additional operations
+    st = np.dtype(dtype).type
+    min = st(np.iinfo(dtype).min)
+    neg_1 = st(-1)
+
+    with pytest.warns(RuntimeWarning, match="overflow encountered"):
+        operation(min, neg_1)
+
+
+@pytest.mark.parametrize("dtype", np.typecodes["UnsignedInteger"])
+def test_scalar_unsigned_integer_overflow(dtype):
+    val = np.dtype(dtype).type(8)
+    with pytest.warns(RuntimeWarning, match="overflow encountered"):
+        -val
+
+    zero = np.dtype(dtype).type(0)
+    -zero  # does not warn
+
+@pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
+@pytest.mark.parametrize("operation", [
+        lambda val, zero: val // zero,
+        lambda val, zero: val % zero, ], ids=["//", "%"])
+def test_scalar_integer_operation_divbyzero(dtype, operation):
+    st = np.dtype(dtype).type
+    val = st(100)
+    zero = st(0)
+
+    with pytest.warns(RuntimeWarning, match="divide by zero"):
+        operation(val, zero)
+
+
+ops_with_names = [
+    ("__lt__", "__gt__", operator.lt, True),
+    ("__le__", "__ge__", operator.le, True),
+    ("__eq__", "__eq__", operator.eq, True),
+    # Note __op__ and __rop__ may be identical here:
+    ("__ne__", "__ne__", operator.ne, True),
+    ("__gt__", "__lt__", operator.gt, True),
+    ("__ge__", "__le__", operator.ge, True),
+    ("__floordiv__", "__rfloordiv__", operator.floordiv, False),
+    ("__truediv__", "__rtruediv__", operator.truediv, False),
+    ("__add__", "__radd__", operator.add, False),
+    ("__mod__", "__rmod__", operator.mod, False),
+    ("__mul__", "__rmul__", operator.mul, False),
+    ("__pow__", "__rpow__", operator.pow, False),
+    ("__sub__", "__rsub__", operator.sub, False),
+]
+
+
+@pytest.mark.parametrize(["__op__", "__rop__", "op", "cmp"], ops_with_names)
+@pytest.mark.parametrize("sctype", [np.float32, np.float64, np.longdouble])
+def test_subclass_deferral(sctype, __op__, __rop__, op, cmp):
+    """
+    This test covers scalar subclass deferral.  Note that this is exceedingly
+    complicated, especially since it tends to fall back to the array paths and
+    these additionally add the "array priority" mechanism.
+
+    The behaviour was modified subtly in 1.22 (to make it closer to how Python
+    scalars work).  Due to its complexity and the fact that subclassing NumPy
+    scalars is probably a bad idea to begin with.  There is probably room
+    for adjustments here.
+    """
+    class myf_simple1(sctype):
+        pass
+
+    class myf_simple2(sctype):
+        pass
+
+    def op_func(self, other):
+        return __op__
+
+    def rop_func(self, other):
+        return __rop__
+
+    myf_op = type("myf_op", (sctype,), {__op__: op_func, __rop__: rop_func})
+
+    # inheritance has to override, or this is correctly lost:
+    res = op(myf_simple1(1), myf_simple2(2))
+    assert type(res) == sctype or type(res) == np.bool_
+    assert op(myf_simple1(1), myf_simple2(2)) == op(1, 2)  # inherited
+
+    # Two independent subclasses do not really define an order.  This could
+    # be attempted, but we do not since Python's `int` does neither:
+    assert op(myf_op(1), myf_simple1(2)) == __op__
+    assert op(myf_simple1(1), myf_op(2)) == op(1, 2)  # inherited
+
+
+def test_longdouble_complex():
+    # Simple test to check longdouble and complex combinations, since these
+    # need to go through promotion, which longdouble needs to be careful about.
+    x = np.longdouble(1)
+    assert x + 1j == 1+1j
+    assert 1j + x == 1+1j
+
+
+@pytest.mark.parametrize(["__op__", "__rop__", "op", "cmp"], ops_with_names)
+@pytest.mark.parametrize("subtype", [float, int, complex, np.float16])
+@np._no_nep50_warning()
+def test_pyscalar_subclasses(subtype, __op__, __rop__, op, cmp):
+    def op_func(self, other):
+        return __op__
+
+    def rop_func(self, other):
+        return __rop__
+
+    # Check that deferring is indicated using `__array_ufunc__`:
+    myt = type("myt", (subtype,),
+               {__op__: op_func, __rop__: rop_func, "__array_ufunc__": None})
+
+    # Just like normally, we should never presume we can modify the float.
+    assert op(myt(1), np.float64(2)) == __op__
+    assert op(np.float64(1), myt(2)) == __rop__
+
+    if op in {operator.mod, operator.floordiv} and subtype == complex:
+        return  # module is not support for complex.  Do not test.
+
+    if __rop__ == __op__:
+        return
+
+    # When no deferring is indicated, subclasses are handled normally.
+    myt = type("myt", (subtype,), {__rop__: rop_func})
+
+    # Check for float32, as a float subclass float64 may behave differently
+    res = op(myt(1), np.float16(2))
+    expected = op(subtype(1), np.float16(2))
+    assert res == expected
+    assert type(res) == type(expected)
+    res = op(np.float32(2), myt(1))
+    expected = op(np.float32(2), subtype(1))
+    assert res == expected
+    assert type(res) == type(expected)
+
+    # Same check for longdouble:
+    res = op(myt(1), np.longdouble(2))
+    expected = op(subtype(1), np.longdouble(2))
+    assert res == expected
+    assert type(res) == type(expected)
+    res = op(np.float32(2), myt(1))
+    expected = op(np.longdouble(2), subtype(1))
+    assert res == expected


### PR DESCRIPTION
In the spirit of https://github.com/Quansight-Labs/numpy_pytorch_interop/issues/10#issuecomment-1369591663, vendor scalar and dtype related tests from numpy. Making sure they actually pass will be in the follow-up, gh-12 and gh-14.

