### PR TITLE
Bump `isort` pre-commit rev to `5.12.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     args: ["--in-place"]
     exclude: ^torch_np/tests/numpy_tests/
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
     args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
For some reason this fixes some problem I was having locally, and it doesn't seem I'm the only one https://github.com/home-assistant/core/issues/86892#issuecomment-1407641288.
<details>
<summary>local error</summary>

```python
An unexpected error has occurred: CalledProcessError: command: ('/home/honno/.cache/pre-commit/reposgg8ow6c/py_env-python3.9/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /home/honno/.cache/pre-commit/reposgg8ow6c
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'
    
stderr:
      error: subprocess-exited-with-error
      
      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [14 lines of output]
          Traceback (most recent call last):
            File "/home/honno/.cache/pre-commit/reposgg8ow6c/py_env-python3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 351, in <module>
              main()
            File "/home/honno/.cache/pre-commit/reposgg8ow6c/py_env-python3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 333, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
            File "/home/honno/.cache/pre-commit/reposgg8ow6c/py_env-python3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 152, in prepare_metadata_for_build_wheel
              return hook(metadata_directory, config_settings)
            File "/tmp/pip-build-env-r0mnfzv1/overlay/lib/python3.9/site-packages/poetry/core/masonry/api.py", line 40, in prepare_metadata_for_build_wheel
              poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
            File "/tmp/pip-build-env-r0mnfzv1/overlay/lib/python3.9/site-packages/poetry/core/factory.py", line 57, in create_poetry
              raise RuntimeError("The Poetry configuration is invalid:\n" + message)
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
          
          [end of output]
```

</details>