### PR TITLE
TST: trim tests of unsupported numpy features

### DIFF
--- a/torch_np/tests/numpy_tests/core/test_numeric.py
+++ b/torch_np/tests/numpy_tests/core/test_numeric.py
@@ -750,19 +750,15 @@ class TestTypes:
         b = np.bool_(0)
         i8, i16, i32, i64 = np.int8(0), np.int16(0), np.int32(0), np.int64(0)
         u8 = np.uint8(0)
-        f32, f64, fld = np.float32(0), np.float64(0), np.longdouble(0)
-        c64, c128, cld = np.complex64(0), np.complex128(0), np.clongdouble(0)
+        f32, f64 = np.float32(0), np.float64(0)
+        c64, c128 = np.complex64(0), np.complex128(0)
 
         # coercion within the same kind
         assert_equal(promote_func(i8, i16), np.dtype(np.int16))
         assert_equal(promote_func(i32, i8), np.dtype(np.int32))
         assert_equal(promote_func(i16, i64), np.dtype(np.int64))
         assert_equal(promote_func(f32, f64), np.dtype(np.float64))
-        assert_equal(promote_func(fld, f32), np.dtype(np.longdouble))
-        assert_equal(promote_func(f64, fld), np.dtype(np.longdouble))
         assert_equal(promote_func(c128, c64), np.dtype(np.complex128))
-        assert_equal(promote_func(cld, c128), np.dtype(np.clongdouble))
-        assert_equal(promote_func(c64, fld), np.dtype(np.clongdouble))
 
         # coercion between kinds
         assert_equal(promote_func(b, i32), np.dtype(np.int32))
@@ -777,7 +773,6 @@ class TestTypes:
         assert_equal(promote_func(f32, u32), np.dtype(np.float64))
         assert_equal(promote_func(f32, c64), np.dtype(np.complex64))
         assert_equal(promote_func(c128, f32), np.dtype(np.complex128))
-        assert_equal(promote_func(cld, f64), np.dtype(np.clongdouble))
 
         # coercion between scalars and 1-D arrays
         assert_equal(promote_func(np.array([b]), i8), np.dtype(np.int8))
@@ -822,9 +817,6 @@ class TestTypes:
         for a in [np.array([True, False]), np.array([-3, 12], dtype=np.int8)]:
             b = 1.234 * a
             assert_equal(b.dtype, np.dtype('f8'), "array type %s" % a.dtype)
-            b = np.longdouble(1.234) * a
-            assert_equal(b.dtype, np.dtype(np.longdouble),
-                         "array type %s" % a.dtype)
             b = np.float64(1.234) * a
             assert_equal(b.dtype, np.dtype('f8'), "array type %s" % a.dtype)
             b = np.float32(1.234) * a
@@ -834,9 +826,6 @@ class TestTypes:
 
             b = 1.234j * a
             assert_equal(b.dtype, np.dtype('c16'), "array type %s" % a.dtype)
-            b = np.clongdouble(1.234j) * a
-            assert_equal(b.dtype, np.dtype(np.clongdouble),
-                         "array type %s" % a.dtype)
             b = np.complex128(1.234j) * a
             assert_equal(b.dtype, np.dtype('c16'), "array type %s" % a.dtype)
             b = np.complex64(1.234j) * a

--- a/torch_np/tests/numpy_tests/lib/test_nanfunctions.py
+++ b/torch_np/tests/numpy_tests/lib/test_nanfunctions.py
@@ -192,7 +192,7 @@ class TestNanFunctions_MinMax:
             assert_almost_equal(res, tgt)
 
     def test_dtype_from_input(self):
-        codes = 'efdgFDG'
+        codes = 'efdFD'
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
                 mat = np.eye(3, dtype=c)
@@ -284,18 +284,6 @@ class TestNanFunctions_MinMax:
                 assert_(res.shape == ())
                 assert_(res != np.nan)
                 assert_(len(w) == 0)
-
-    def test_object_array(self):
-        arr = np.array([[1.0, 2.0], [np.nan, 4.0], [np.nan, np.nan]], dtype=object)
-        assert_equal(np.nanmin(arr), 1.0)
-        assert_equal(np.nanmin(arr, axis=0), [1.0, 2.0])
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            # assert_equal does not work on object arrays of nan
-            assert_equal(list(np.nanmin(arr, axis=1)), [1.0, 4.0, np.nan])
-            assert_(len(w) == 1, 'no warning raised')
-            assert_(issubclass(w[0].category, RuntimeWarning))
 
     @pytest.mark.parametrize("dtype", np.typecodes["AllFloat"])
     def test_initial(self, dtype):
@@ -444,7 +432,7 @@ for _v in _TEST_ARRAYS.values():
 @pytest.mark.xfail(reason='TODO: implement')
 @pytest.mark.parametrize(
     "dtype",
-    np.typecodes["AllInteger"] + np.typecodes["AllFloat"] + "O",
+    np.typecodes["AllInteger"] + np.typecodes["AllFloat"]
 )
 @pytest.mark.parametrize("mat", _TEST_ARRAYS.values(), ids=_TEST_ARRAYS.keys())
 class TestNanFunctions_NumberTypes:
@@ -491,10 +479,7 @@ class TestNanFunctions_NumberTypes:
 
             assert_almost_equal(out, tgt)
 
-            if dtype == "O":
-                assert type(out) is type(tgt)
-            else:
-                assert out.dtype == tgt.dtype
+            assert out.dtype == tgt.dtype
 
     @pytest.mark.parametrize(
         "nanfunc,func",
@@ -507,10 +492,7 @@ class TestNanFunctions_NumberTypes:
         out = nanfunc(mat, ddof=0.5)
 
         assert_almost_equal(out, tgt)
-        if dtype == "O":
-            assert type(out) is type(tgt)
-        else:
-            assert out.dtype == tgt.dtype
+        assert out.dtype == tgt.dtype
 
 
 class SharedNanFunctionsTestsMixin:
@@ -540,11 +522,11 @@ class SharedNanFunctionsTestsMixin:
 
     def test_dtype_from_dtype(self):
         mat = np.eye(3)
-        codes = 'efdgFDG'
+        codes = 'efdFD'
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
                 with suppress_warnings() as sup:
-                    if nf in {np.nanstd, np.nanvar} and c in 'FDG':
+                    if nf in {np.nanstd, np.nanvar} and c in 'FD':
                         # Giving the warning is a small bug, see gh-8000
                         sup.filter(np.ComplexWarning)
                     tgt = rf(mat, dtype=np.dtype(c), axis=1).dtype.type
@@ -557,11 +539,11 @@ class SharedNanFunctionsTestsMixin:
 
     def test_dtype_from_char(self):
         mat = np.eye(3)
-        codes = 'efdgFDG'
+        codes = 'efdFD'
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
                 with suppress_warnings() as sup:
-                    if nf in {np.nanstd, np.nanvar} and c in 'FDG':
+                    if nf in {np.nanstd, np.nanvar} and c in 'FD':
                         # Giving the warning is a small bug, see gh-8000
                         sup.filter(np.ComplexWarning)
                     tgt = rf(mat, dtype=c, axis=1).dtype.type
@@ -573,7 +555,7 @@ class SharedNanFunctionsTestsMixin:
                     assert_(res is tgt)
 
     def test_dtype_from_input(self):
-        codes = 'efdgFDG'
+        codes = 'efdFD'
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
                 mat = np.eye(3, dtype=c)
@@ -760,12 +742,12 @@ class TestNanFunctions_MeanVarStd(SharedNanFunctionsTestsMixin):
 
     def test_dtype_error(self):
         for f in self.nanfuncs:
-            for dtype in [np.bool_, np.int_, np.object_]:
+            for dtype in [np.bool_, np.int_]:
                 assert_raises(TypeError, f, _ndat, axis=1, dtype=dtype)
 
     def test_out_dtype_error(self):
         for f in self.nanfuncs:
-            for dtype in [np.bool_, np.int_, np.object_]:
+            for dtype in [np.bool_, np.int_]:
                 out = np.empty(_ndat.shape[0], dtype=dtype)
                 assert_raises(TypeError, f, _ndat, axis=1, out=out)
 
@@ -850,13 +832,8 @@ class TestNanFunctions_MeanVarStd(SharedNanFunctionsTestsMixin):
             np.testing.assert_allclose(ret, reference)
 
 
-_TIME_UNITS = (
-    "Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps", "fs", "as"
-)
-
-# All `inexact` + `timdelta64` type codes
+# All `inexact` type codes
 _TYPE_CODES = list(np.typecodes["AllFloat"])
-_TYPE_CODES += [f"m8[{unit}]" for unit in _TIME_UNITS]
 
 
 @pytest.mark.xfail(reason='TODO: implement')

--- a/torch_np/tests/numpy_tests/lib/test_shape_base_.py
+++ b/torch_np/tests/numpy_tests/lib/test_shape_base_.py
@@ -124,37 +124,6 @@ class TestApplyAlongAxis:
         assert_array_equal(apply_along_axis(np.sum, 0, a),
                            [[27, 30, 33], [36, 39, 42], [45, 48, 51]])
 
-    def test_preserve_subclass(self):
-        def double(row):
-            return row * 2
-
-        class MyNDArray(np.ndarray):
-            pass
-
-        m = np.array([[0, 1], [2, 3]]).view(MyNDArray)
-        expected = np.array([[0, 2], [4, 6]]).view(MyNDArray)
-
-        result = apply_along_axis(double, 0, m)
-        assert_(isinstance(result, MyNDArray))
-        assert_array_equal(result, expected)
-
-        result = apply_along_axis(double, 1, m)
-        assert_(isinstance(result, MyNDArray))
-        assert_array_equal(result, expected)
-
-    def test_subclass(self):
-        class MinimalSubclass(np.ndarray):
-            data = 1
-
-        def minimal_function(array):
-            return array.data
-
-        a = np.zeros((6, 3)).view(MinimalSubclass)
-
-        assert_array_equal(
-            apply_along_axis(minimal_function, 0, a), np.array([1, 1, 1])
-        )
-
     def test_scalar_array(self, cls=np.ndarray):
         a = np.ones((6, 3)).view(cls)
         res = apply_along_axis(np.sum, 0, a)
@@ -211,13 +180,6 @@ class TestApplyAlongAxis:
         ], axis=-1).view(cls)
         assert_equal(type(actual), type(expected))
         assert_equal(actual, expected)
-
-    def test_subclass_preservation(self):
-        class MinimalSubclass(np.ndarray):
-            pass
-        self.test_scalar_array(MinimalSubclass)
-        self.test_0d_array(MinimalSubclass)
-        self.test_axis_insertion(MinimalSubclass)
 
     def test_axis_insertion_ma(self):
         def f1to2(x):


### PR DESCRIPTION
datatime, objects, structured dtypes, longdouble