### PR TITLE
Basic `ndarray.flags` implementation

### DIFF
--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -50,7 +50,7 @@ class Flags:
         if attr.islower() and attr.upper() in FLAGS:
             return self[attr.upper()]
         else:
-            raise AttributeError(f"No flag '{attr}'")
+            raise AttributeError(f"No flag attribute '{attr}'")
 
     def __getitem__(self, key):
         if key in SHORTHAND_TO_FLAGS.keys():
@@ -61,7 +61,7 @@ class Flags:
             except KeyError as e:
                 raise NotImplementedError(f"{key=}") from e
         else:
-            raise KeyError(f"No flag '{key}'")
+            raise KeyError(f"No flag key '{key}'")
 
 
 ##################### ndarray class ###########################

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -110,13 +110,7 @@ class ndarray:
     @property
     def flags(self):
         # Note contiguous in torch is assumed C-style
-        flag_to_value = {"C_CONTIGUOUS": self._tensor.is_contiguous()}
-        if flag_to_value["C_CONTIGUOUS"]:
-            # There's no proper way to determine if a tensor is Fortran-style
-            # contiguous in torch, but at least we know it isn't when it is
-            # C-style.
-            flag_to_value["F_CONTIGUOUS"] = False
-        return Flags(flag_to_value)
+        return Flags({"C_CONTIGUOUS": self._tensor.is_contiguous()})
 
     @property
     def T(self):


### PR DESCRIPTION
Implements [`x.flags`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flags.html), which mostly raises `NotImplementedError()`. Seemed nice if just for porting NumPy's own tests.