### PR TITLE
make better split between wrappers and torch implementations

### DIFF
--- a/torch_np/_decorators.py
+++ b/torch_np/_decorators.py
@@ -15,7 +15,7 @@ def dtype_to_torch(func):
         torch_dtype = None
         if dtype is not None:
             dtype = _dtypes.dtype(dtype)
-            torch_dtype = dtype._scalar_type.torch_dtype
+            torch_dtype = dtype.torch_dtype
         return func(*args, dtype=torch_dtype, **kwds)
 
     return wrapped

--- a/torch_np/_detail/_reductions.py
+++ b/torch_np/_detail/_reductions.py
@@ -146,9 +146,7 @@ def std(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
         raise NotImplementedError
 
     dtype = _atleast_float(dtype, tensor.dtype)
-
-    if dtype is not None:
-        tensor = tensor.to(dtype)
+    tensor = _util.cast_if_needed(tensor, dtype)
     result = tensor.std(dim=axis, correction=ddof)
 
     return result
@@ -159,9 +157,7 @@ def var(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
         raise NotImplementedError
 
     dtype = _atleast_float(dtype, tensor.dtype)
-
-    if dtype is not None:
-        tensor = tensor.to(dtype)
+    tensor = _util.cast_if_needed(tensor, dtype)
     result = tensor.var(dim=axis, correction=ddof)
 
     return result
@@ -204,10 +200,9 @@ def average(a_tensor, axis, w_tensor):
         a_tensor = a_tensor.to(result_dtype)
 
     result_dtype = _dtypes_impl.result_type_impl([a_tensor.dtype, w_tensor.dtype])
-    if a_tensor.dtype != result_dtype:
-        a_tensor = a_tensor.to(result_dtype)
-    if w_tensor.dtype != result_dtype:
-        w_tensor = w_tensor.to(result_dtype)
+
+    a_tensor = _util.cast_if_needed(a_tensor, result_dtype)
+    w_tensor = _util.cast_if_needed(w_tensor, result_dtype)
 
     # axis
     if axis is None:
@@ -258,7 +253,7 @@ def quantile(a_tensor, q_tensor, axis, method):
         axis = _util.normalize_axis_tuple(axis, a_tensor.ndim)
     axis = _util.allow_only_single_axis(axis)
 
-    q_tensor = q_tensor.to(a_tensor.dtype)
+    q_tensor = _util.cast_if_needed(q_tensor, a_tensor.dtype)
 
     (a_tensor, q_tensor), axis = _util.axis_none_ravel(a_tensor, q_tensor, axis=axis)
 

--- a/torch_np/_detail/_util.py
+++ b/torch_np/_detail/_util.py
@@ -34,6 +34,13 @@ class UFuncTypeError(TypeError, RuntimeError):
     pass
 
 
+def cast_if_needed(tensor, dtype):
+    # NB: no casting if dtype=None
+    if tensor.dtype != dtype:
+        tensor = tensor.to(dtype)
+    return tensor
+
+
 # a replica of the version in ./numpy/numpy/core/src/multiarray/common.h
 def normalize_axis_index(ax, ndim, argname=None):
     if not (-ndim <= ax < ndim):
@@ -156,10 +163,7 @@ def cast_dont_broadcast(tensors, target_dtype, casting):
                 f"Cannot cast array data from {tensor.dtype} to"
                 f" {target_dtype} according to the rule '{casting}'"
             )
-
-        # cast if needed
-        if tensor.dtype != target_dtype:
-            tensor = tensor.to(target_dtype)
+        tensor = cast_if_needed(tensor, target_dtype)
         cast_tensors.append(tensor)
 
     return tuple(cast_tensors)
@@ -200,8 +204,7 @@ def cast_and_broadcast(tensors, out_param, casting):
             )
 
         # cast arr if needed
-        if tensor.dtype != target_dtype:
-            tensor = tensor.to(target_dtype)
+        tensor = cast_if_needed(tensor, target_dtype)
 
         # `out` broadcasts `tensor`
         if tensor.shape != target_shape:
@@ -285,8 +288,7 @@ def _coerce_to_tensor(obj, dtype=None, copy=False, ndmin=0):
         tensor = torch.as_tensor(obj, dtype=torch_dtype)
 
     # type cast if requested
-    if dtype is not None:
-        tensor = tensor.to(dtype)
+    tensor = cast_if_needed(tensor, dtype)
 
     # adjust ndim if needed
     ndim_extra = ndmin - tensor.ndim

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -80,6 +80,17 @@ def tensor_angle(z, deg=False):
     return result
 
 
+# ### sorting ###
+
+def tensor_argsort(tensor, axis=-1, kind=None, order=None):
+    if order is not None:
+        raise NotImplementedError
+    stable = True if kind == "stable" else False
+    if axis is None:
+        axis = -1
+    return torch.argsort(tensor, stable=stable, dim=axis, descending=False)
+
+
 # ### splits ###
 
 

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -82,6 +82,7 @@ def tensor_angle(z, deg=False):
 
 # ### sorting ###
 
+
 def tensor_argsort(tensor, axis=-1, kind=None, order=None):
     if order is not None:
         raise NotImplementedError
@@ -89,6 +90,45 @@ def tensor_argsort(tensor, axis=-1, kind=None, order=None):
     if axis is None:
         axis = -1
     return torch.argsort(tensor, stable=stable, dim=axis, descending=False)
+
+
+# ### tri*-something ###
+
+
+def tri(N, M, k, dtype):
+    if M is None:
+        M = N
+    tensor = torch.ones((N, M), dtype=dtype)
+    tensor = torch.tril(tensor, diagonal=k)
+    return tensor
+
+
+def triu_indices_from(tensor, k):
+    if tensor.ndim != 2:
+        raise ValueError("input array must be 2-d")
+    result = torch.triu_indices(tensor.shape[0], tensor.shape[1], offset=k)
+    return result
+
+
+def tril_indices_from(tensor, k=0):
+    if tensor.ndim != 2:
+        raise ValueError("input array must be 2-d")
+    result = torch.tril_indices(tensor.shape[0], tensor.shape[1], offset=k)
+    return result
+
+
+def tril_indices(n, k=0, m=None):
+    if m is None:
+        m = n
+    result = torch.tril_indices(n, m, offset=k)
+    return result
+
+
+def triu_indices(n, k=0, m=None):
+    if m is None:
+        m = n
+    result = torch.triu_indices(n, m, offset=k)
+    return result
 
 
 # ### splits ###

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -72,6 +72,20 @@ def split_helper_list(tensor, indices_or_sections, axis, strict=False):
     return torch.split(tensor, lst, axis)
 
 
+def clip(tensor, t_min, t_max):
+    if t_min is not None:
+        t_min = torch.broadcast_to(t_min, tensor.shape)
+
+    if t_max is not None:
+        t_max = torch.broadcast_to(t_max, tensor.shape)
+
+    if t_min is None and t_max is None:
+        raise ValueError("One of max or min must be given")
+
+    result = tensor.clamp(t_min, t_max)
+    return result
+
+
 def diff(a_tensor, n=1, axis=-1, prepend_tensor=None, append_tensor=None):
     axis = _util.normalize_axis_index(axis, a_tensor.ndim)
 

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -246,6 +246,55 @@ def concatenate(tensors, axis=0, out=None, dtype=None, casting="same_kind"):
     return result
 
 
+def stack(tensors, axis=0, out=None, *, dtype=None, casting="same_kind"):
+    shapes = {t.shape for t in tensors}
+    if len(shapes) != 1:
+        raise ValueError("all input arrays must have the same shape")
+
+    result_ndim = tensors[0].ndim + 1
+    axis = _util.normalize_axis_index(axis, result_ndim)
+
+    sl = (slice(None),) * axis + (None,)
+    expanded_tensors = [tensor[sl] for tensor in tensors]
+    result = concatenate(expanded_tensors, axis=axis, out=out, dtype=dtype, casting=casting)
+
+    return result
+
+
+def column_stack(tensors_, *, dtype=None, casting="same_kind"):
+    tensors = []
+    for t in tensors_:
+        if t.ndim < 2:
+            t = _util._coerce_to_tensor(t, copy=False, ndmin=2).mT
+        tensors.append(t)
+
+    result = concatenate(tensors, 1, dtype=dtype, casting=casting)
+    return result
+
+
+def dstack(tensors, *, dtype=None, casting="same_kind"):
+    tensors = torch.atleast_3d(tensors)
+    result = concatenate(tensors, 2, dtype=dtype, casting=casting)
+    return result
+
+
+def hstack(tensors, *, dtype=None, casting="same_kind"):
+    tensors = torch.atleast_1d(tensors)
+
+    # As a special case, dimension 0 of 1-dimensional arrays is "horizontal"s
+    if tensors and tensors[0].ndim == 1:
+        result = concatenate(tensors, 0, dtype=dtype, casting=casting)
+    else:
+        result = concatenate(tensors, 1, dtype=dtype, casting=casting)
+    return result
+
+
+def vstack(tensors, *, dtype=None, casting="same_kind"):
+    tensors = torch.atleast_2d(tensors)
+    result = concatenate(tensors, 0, dtype=dtype, casting=casting)
+    return result
+
+
 # #### cov & corrcoef
 
 

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -64,7 +64,13 @@ def real_if_close(x, tol=100):
     # XXX: copies vs views; numpy seems to return a copy?
     if not torch.is_complex(x):
         return x
-    mask = torch.abs(x.imag) < tol * torch.finfo(x.dtype).eps
+    if tol > 1:
+        # Undocumented in numpy: if tol < 1, it's an absolute tolerance!
+        # Otherwise, tol > 1 is relative tolerance, in units of the dtype epsilon
+        # https://github.com/numpy/numpy/blob/v1.24.0/numpy/lib/type_check.py#L577
+        tol = tol * torch.finfo(x.dtype).eps
+
+    mask = torch.abs(x.imag) < tol
     if mask.all():
         return x.real
     else:

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -301,11 +301,7 @@ def vstack(tensors, *, dtype=None, casting="same_kind"):
 # #### cov & corrcoef
 
 
-def corrcoef(xy_tensor, rowvar=True, *, dtype=None):
-    if rowvar is False:
-        # xy_tensor is at least 2D, so using .T is safe
-        xy_tensor = x_tensor.T
-
+def corrcoef(xy_tensor, *, dtype=None):
     is_half = dtype == torch.float16
     if is_half:
         # work around torch's "addmm_impl_cpu_" not implemented for 'Half'"

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -97,14 +97,13 @@ def diff(a_tensor, n=1, axis=-1, prepend_tensor=None, append_tensor=None):
 
 # #### concatenate and relatives
 
+
 def concatenate(tensors, axis=0, out=None, dtype=None, casting="same_kind"):
     # np.concatenate ravels if axis=None
     tensors, axis = _util.axis_none_ravel(*tensors, axis=axis)
 
-    # figure out the type of the inputs and outputs
-    if out is None and dtype is None:
-        out_dtype = None
-    else:
+    if out is not None or dtype is not None:
+        # figure out the type of the inputs and outputs
         out_dtype = out.dtype.torch_dtype if dtype is None else dtype
 
         # cast input arrays if necessary; do not broadcast them agains `out`
@@ -120,7 +119,8 @@ def concatenate(tensors, axis=0, out=None, dtype=None, casting="same_kind"):
 
 # #### cov & corrcoef
 
-def corrcoef(xy_tensor,  rowvar=True, *, dtype=None):
+
+def corrcoef(xy_tensor, rowvar=True, *, dtype=None):
     if rowvar is False:
         # xy_tensor is at least 2D, so using .T is safe
         xy_tensor = x_tensor.T
@@ -194,4 +194,3 @@ def meshgrid(*xi_tensors, copy=True, sparse=False, indexing="xy"):
         output = [x.clone() for x in output]
 
     return output
-

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -54,7 +54,7 @@ def tensor_iscomplex(x):
 def tensor_isreal(x):
     if torch.is_complex(x):
         return torch.as_tensor(x).imag == 0
-    result = torch.zeros_like(x, dtype=torch.bool)
+    result = torch.ones_like(x, dtype=torch.bool)
     if result.ndim == 0:
         result = result.item()
     return result

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -323,3 +323,12 @@ def meshgrid(*xi_tensors, copy=True, sparse=False, indexing="xy"):
         output = [x.clone() for x in output]
 
     return output
+
+
+
+def bincount(x_tensor, /, weights_tensor=None, minlength=0):
+    int_dtype = _dtypes_impl.default_int_dtype
+    (x_tensor,) = _util.cast_dont_broadcast((x_tensor,), int_dtype, casting="safe")
+
+    result = torch.bincount(x_tensor, weights_tensor, minlength)
+    return result

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -155,6 +155,8 @@ def split_helper_int(tensor, indices_or_sections, axis, strict=False):
     if not isinstance(indices_or_sections, int):
         raise NotImplementedError("split: indices_or_sections")
 
+    axis = _util.normalize_axis_index(axis, tensor.ndim)
+
     # numpy: l%n chunks of size (l//n + 1), the rest are sized l//n
     l, n = tensor.shape[axis], indices_or_sections
 
@@ -193,6 +195,26 @@ def split_helper_list(tensor, indices_or_sections, axis):
     lst += [0] * num_extra
 
     return torch.split(tensor, lst, axis)
+
+
+def hsplit(tensor, indices_or_sections):
+    if tensor.ndim == 0:
+        raise ValueError("hsplit only works on arrays of 1 or more dimensions")
+    axis = 1 if tensor.ndim > 1 else 0
+    return split_helper(tensor, indices_or_sections, axis, strict=True)
+
+
+def vsplit(tensor, indices_or_sections):
+    if tensor.ndim < 2:
+        raise ValueError("vsplit only works on arrays of 2 or more dimensions")
+    return split_helper(tensor, indices_or_sections, 0, strict=True)
+
+
+def dsplit(tensor, indices_or_sections):
+    if tensor.ndim < 3:
+        raise ValueError("dsplit only works on arrays of 3 or more dimensions")
+    return split_helper(tensor, indices_or_sections, 2, strict=True)
+
 
 
 def clip(tensor, t_min, t_max):

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -39,6 +39,47 @@ def tensor_isclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
     return result
 
 
+# ### is arg real or complex valued ###
+
+
+def tensor_iscomplex(x):
+    if torch.is_complex(x):
+        return torch.as_tensor(x).imag != 0
+    result = torch.zeros_like(x, dtype=torch.bool)
+    if result.ndim == 0:
+        result = result.item()
+    return result
+
+
+def tensor_isreal(x):
+    if torch.is_complex(x):
+        return torch.as_tensor(x).imag == 0
+    result = torch.zeros_like(x, dtype=torch.bool)
+    if result.ndim == 0:
+        result = result.item()
+    return result
+
+
+def tensor_real_if_close(x, tol=100):
+    if not torch.is_complex(x):
+        return x
+    mask = torch.abs(x.imag) < tol * torch.finfo(x.dtype).eps
+    if mask.all():
+        return x.real
+    else:
+        return x
+
+
+# ### math functions ###
+
+
+def tensor_angle(z, deg=False):
+    result = torch.angle(z)
+    if deg:
+        result *= 180 / torch.pi
+    return result
+
+
 # ### splits ###
 
 

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -33,8 +33,8 @@ def tensor_equiv(a1_t, a2_t):
 
 def isclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
     dtype = _dtypes_impl.result_type_impl((a.dtype, b.dtype))
-    a = a.to(dtype)
-    b = b.to(dtype)
+    a = _util.cast_if_needed(a, dtype)
+    b = _util.cast_if_needed(b, dtype)
     result = torch.isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
     return result
 
@@ -308,9 +308,7 @@ def corrcoef(xy_tensor, *, dtype=None):
         # work around torch's "addmm_impl_cpu_" not implemented for 'Half'"
         dtype = torch.float32
 
-    if dtype is not None:
-        xy_tensor = xy_tensor.to(dtype)
-
+    xy_tensor = _util.cast_if_needed(xy_tensor, dtype)
     result = torch.corrcoef(xy_tensor)
 
     if is_half:
@@ -336,8 +334,7 @@ def cov(
         # work around torch's "addmm_impl_cpu_" not implemented for 'Half'"
         dtype = torch.float32
 
-    if dtype is not None:
-        m_tensor = m_tensor.to(dtype)
+    m_tensor = _util.cast_if_needed(m_tensor, dtype)
 
     result = torch.cov(
         m_tensor, correction=ddof, aweights=aweights_tensor, fweights=fweights_tensor

--- a/torch_np/_dtypes.py
+++ b/torch_np/_dtypes.py
@@ -254,10 +254,6 @@ def dtype(arg):
     return DType(arg)
 
 
-def torch_dtype_from(dtype_arg):
-    return dtype(dtype_arg).torch_dtype
-
-
 class DType:
     def __init__(self, arg):
         # a pytorch object?

--- a/torch_np/_getlimits.py
+++ b/torch_np/_getlimits.py
@@ -4,12 +4,12 @@ from . import _dtypes
 
 
 def finfo(dtyp):
-    torch_dtype = _dtypes.torch_dtype_from(dtyp)
+    torch_dtype = _dtypes.dtype(dtyp).torch_dtype
     return torch.finfo(torch_dtype)
 
 
 def iinfo(dtyp):
-    torch_dtype = _dtypes.torch_dtype_from(dtyp)
+    torch_dtype = _dtypes.dtype(dtyp).torch_dtype
     return torch.iinfo(torch_dtype)
 
 

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -139,11 +139,7 @@ class ndarray:
         self._tensor.imag = asarray(value).get()
 
     def round(self, decimals=0, out=None):
-        tensor = self._tensor
-        if torch.is_floating_point(tensor):
-            result = torch.round(tensor, decimals=decimals)
-        else:
-            result = tensor
+        result = _impl.round(self._tensor, decimals)
         return _helpers.result_or_out(result, out)
 
     # ctors
@@ -328,32 +324,16 @@ class ndarray:
     ### methods to match namespace functions
 
     def squeeze(self, axis=None):
-        if axis == ():
-            tensor = self._tensor
-        elif axis is None:
-            tensor = self._tensor.squeeze()
-        else:
-            tensor = self._tensor.squeeze(axis)
-        return ndarray._from_tensor_and_base(tensor, self)
+        result = _impl.squeeze(self._tensor, axis)
+        return ndarray._from_tensor_and_base(result, self)
 
     def reshape(self, *shape, order="C"):
-        newshape = shape[0] if len(shape) == 1 else shape
-        # if sh = (1, 2, 3), numpy allows both .reshape(sh) and .reshape(*sh)
-        if order != "C":
-            raise NotImplementedError
-        tensor = self._tensor.reshape(newshape)
-        return ndarray._from_tensor_and_base(tensor, self)
+        result = _impl.reshape(self._tensor, *shape, order=order)
+        return ndarray._from_tensor_and_base(result, self)
 
     def transpose(self, *axes):
-        # numpy allows both .reshape(sh) and .reshape(*sh)
-        axes = axes[0] if len(axes) == 1 else axes
-        if axes == () or axes is None:
-            axes = tuple(range(self.ndim))[::-1]
-        try:
-            tensor = self._tensor.permute(axes)
-        except RuntimeError:
-            raise ValueError("axes don't match array")
-        return ndarray._from_tensor_and_base(tensor, self)
+        result = _impl.transpose(self._tensor, *axes)
+        return ndarray._from_tensor_and_base(result, self)
 
     def swapaxes(self, axis1, axis2):
         return asarray(_flips.swapaxes(self._tensor, axis1, axis2))

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -149,7 +149,7 @@ class ndarray:
     # ctors
     def astype(self, dtype):
         newt = ndarray()
-        torch_dtype = _dtypes.torch_dtype_from(dtype)
+        torch_dtype = _dtypes.dtype(dtype).torch_dtype
         newt._tensor = self._tensor.to(torch_dtype)
         return newt
 
@@ -439,7 +439,7 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
     # is a specific dtype requrested?
     torch_dtype = None
     if dtype is not None:
-        torch_dtype = _dtypes.torch_dtype_from(dtype)
+        torch_dtype = _dtypes.dtype(dtype).torch_dtype
         base = None
 
     tensor = _util._coerce_to_tensor(obj, torch_dtype, copy, ndmin)

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -12,6 +12,7 @@ from ._decorators import (
     emulate_out_arg,
 )
 from ._detail import _dtypes_impl, _flips, _reductions, _util
+from ._detail import implementations as _impl
 
 newaxis = None
 
@@ -367,24 +368,8 @@ class ndarray:
         return tuple(asarray(_) for _ in tensor.nonzero(as_tuple=True))
 
     def clip(self, min, max, out=None):
-        tensor = self._tensor
-        a_min, a_max = min, max
-
-        t_min = None
-        if a_min is not None:
-            t_min = asarray(a_min).get()
-            t_min = torch.broadcast_to(t_min, tensor.shape)
-
-        t_max = None
-        if a_max is not None:
-            t_max = asarray(a_max).get()
-            t_max = torch.broadcast_to(t_max, tensor.shape)
-
-        if t_min is None and t_max is None:
-            raise ValueError("One of max or min must be given")
-
-        result = tensor.clamp(t_min, t_max)
-
+        tensor, t_min, t_max = _helpers.to_tensors_or_none(self, min, max)
+        result = _impl.clip(tensor, t_min, t_max)
         return _helpers.result_or_out(result, out)
 
     argmin = emulate_out_arg(axis_keepdims_wrapper(_reductions.argmin))

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -462,16 +462,12 @@ def cov(
 
         m = concatenate((m, y), axis=0)
 
-#    if ddof is None:
-#        if bias == 0:
-#            ddof = 1
-#        else:
-#            ddof = 0
-
     m_tensor, fweights_tensor, aweights_tensor = _helpers.to_tensors_or_none(
         m, fweights, aweights
     )
-    result = _impl.cov(m_tensor, bias, ddof, fweights_tensor, aweights_tensor, dtype=dtype)
+    result = _impl.cov(
+        m_tensor, bias, ddof, fweights_tensor, aweights_tensor, dtype=dtype
+    )
     return asarray(result)
 
 

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -705,7 +705,6 @@ def triu(m, k=0):
     return m.triu(k)
 
 
-# YYY: pattern: return sequence
 def tril_indices(n, k=0, m=None):
     if m is None:
         m = n
@@ -1012,12 +1011,8 @@ def diff(a, n=1, axis=-1, prepend=NoValue, append=NoValue):
 
 @asarray_replacer()
 def argsort(a, axis=-1, kind=None, order=None):
-    if order is not None:
-        raise NotImplementedError
-    stable = True if kind == "stable" else False
-    if axis is None:
-        axis = -1
-    return torch.argsort(a, stable=stable, dim=axis, descending=False)
+    result = _impl.tensor_argsort(a, axis, kind, order)
+    return result
 
 
 ##### math functions

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -261,6 +261,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis
 def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
     if axis != 0 or not endpoint:
         raise NotImplementedError
+    start, stop = _helpers.to_tensors(start, stop)
     result = _impl.geomspace(start, stop, num, endpoint, dtype, axis)
     return asarray(result)
 
@@ -954,7 +955,7 @@ def diff(a, n=1, axis=-1, prepend=NoValue, append=NoValue):
 
 @asarray_replacer()
 def argsort(a, axis=-1, kind=None, order=None):
-    result = _impl.tensor_argsort(a, axis, kind, order)
+    result = _impl.argsort(a, axis, kind, order)
     return result
 
 
@@ -963,7 +964,7 @@ def argsort(a, axis=-1, kind=None, order=None):
 
 @asarray_replacer()
 def angle(z, deg=False):
-    result = _impl.tensor_angle(z, deg)
+    result = _impl.angle(z, deg)
     return result
 
 
@@ -984,19 +985,19 @@ def imag(a):
 
 @asarray_replacer()
 def real_if_close(a, tol=100):
-    result = _impl.tensor_real_if_close(a, tol=tol)
+    result = _impl.real_if_close(a, tol=tol)
     return result
 
 
 @asarray_replacer()
 def iscomplex(x):
-    result = _impl.tensor_iscomplex(x)
+    result = _impl.iscomplex(x)
     return result  # XXX: missing .item on a zero-dim value; a case for array_or_scalar(value) ?
 
 
 @asarray_replacer()
 def isreal(x):
-    result = _impl.tensor_isreal(x)
+    result = _impl.isreal(x)
     return result
 
 
@@ -1036,13 +1037,13 @@ def isscalar(a):
 
 def isclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
     a_t, b_t = _helpers.to_tensors(a, b)
-    result = _impl.tensor_isclose(a_t, b_t, rtol, atol, equal_nan=equal_nan)
+    result = _impl.isclose(a_t, b_t, rtol, atol, equal_nan=equal_nan)
     return asarray(result)
 
 
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
     a_t, b_t = _helpers.to_tensors(a, b)
-    result = _impl.tensor_isclose(a_t, b_t, rtol, atol, equal_nan=equal_nan)
+    result = _impl.isclose(a_t, b_t, rtol, atol, equal_nan=equal_nan)
     return result.all()
 
 

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -595,9 +595,9 @@ def flatnonzero(a):
 
 
 def argwhere(a):
-    arr = asarray(a)
-    tensor = arr.get()
-    return asarray(torch.argwhere(tensor))
+    tensor = asarray(a).get()
+    result = torch.argwhere(tensor)
+    return asarray(result)
 
 
 from ._decorators import emulate_out_arg
@@ -606,13 +606,10 @@ from ._ndarray import axis_keepdims_wrapper
 count_nonzero = emulate_out_arg(axis_keepdims_wrapper(_reductions.count_nonzero))
 
 
-@asarray_replacer()
 def roll(a, shift, axis=None):
-    if axis is not None:
-        axis = _util.normalize_axis_tuple(axis, a.ndim, allow_duplicate=True)
-        if not isinstance(shift, tuple):
-            shift = (shift,) * len(axis)
-    return a.roll(shift, axis)
+    tensor = asarray(a).get()
+    result = _impl.roll(tensor, shift, axis)
+    return asarray(result)
 
 
 def round_(a, decimals=0, out=None):

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -601,7 +601,8 @@ from torch import broadcast_shapes
 # YYY: pattern: tuple of arrays as input, tuple of arrays as output; cf nonzero
 def broadcast_arrays(*args, subok=False):
     _util.subok_not_ok(subok=subok)
-    res = torch.broadcast_tensors(*[asarray(a).get() for a in args])
+    tensors = _helpers.to_tensors(*args)
+    res = torch.broadcast_tensors(*tensors)
     return tuple(asarray(_) for _ in res)
 
 
@@ -706,44 +707,32 @@ def triu(m, k=0):
 
 
 def tril_indices(n, k=0, m=None):
-    if m is None:
-        m = n
-    tensor_2 = torch.tril_indices(n, m, offset=k)
-    return tuple(asarray(_) for _ in tensor_2)
+    result = _impl.tril_indices(n, k, m)
+    return tuple(asarray(t) for t in result)
 
 
 def triu_indices(n, k=0, m=None):
-    if m is None:
-        m = n
-    tensor_2 = torch.tril_indices(n, m, offset=k)
-    return tuple(asarray(_) for _ in tensor_2)
+    result = _impl.triu_indices(n, k, m)
+    return tuple(asarray(t) for t in result)
 
 
-# YYY: pattern: array in, sequence of arrays out
 def tril_indices_from(arr, k=0):
-    arr = asarray(arr).get()
-    if arr.ndim != 2:
-        raise ValueError("input array must be 2-d")
-    tensor_2 = torch.tril_indices(arr.shape[0], arr.shape[1], offset=k)
-    return tuple(asarray(_) for _ in tensor_2)
+    tensor = asarray(arr).get()
+    result = _impl.tril_indices_from(tensor, k)
+    return tuple(asarray(t) for t in result)
 
 
 def triu_indices_from(arr, k=0):
-    arr = asarray(arr).get()
-    if arr.ndim != 2:
-        raise ValueError("input array must be 2-d")
-    tensor_2 = torch.tril_indices(arr.shape[0], arr.shape[1], offset=k)
-    return tuple(asarray(_) for _ in tensor_2)
+    tensor = asarray(arr).get()
+    result = _impl.triu_indices_from(tensor, k)
+    return tuple(asarray(t) for t in result)
 
 
 @_decorators.dtype_to_torch
 def tri(N, M=None, k=0, dtype=float, *, like=None):
     _util.subok_not_ok(like)
-    if M is None:
-        M = N
-    tensor = torch.ones((N, M), dtype=dtype)
-    tensor = torch.tril(tensor, diagonal=k)
-    return asarray(tensor)
+    result = _impl.tri(N, M, k, dtype)
+    return asarray(result)
 
 
 ###### reductions

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -1107,17 +1107,15 @@ def isscalar(a):
 
 
 def isclose(a, b, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
-    a, b = _helpers.to_tensors(a, b)
-    dtype = result_type(a, b)
-    torch_dtype = dtype.type.torch_dtype
-    a = a.to(torch_dtype)
-    b = b.to(torch_dtype)
-    return asarray(torch.isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
+    a_t, b_t = _helpers.to_tensors(a, b)
+    result = _impl.tensor_isclose(a_t, b_t, rtol, atol, equal_nan=equal_nan)
+    return asarray(result)
 
 
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-    arr_res = isclose(a, b, rtol, atol, equal_nan)
-    return arr_res.all()
+    a_t, b_t = _helpers.to_tensors(a, b)
+    result = _impl.tensor_isclose(a_t, b_t, rtol, atol, equal_nan=equal_nan)
+    return result.all()
 
 
 def array_equal(a1, a2, equal_nan=False):
@@ -1128,12 +1126,8 @@ def array_equal(a1, a2, equal_nan=False):
 
 def array_equiv(a1, a2):
     a1_t, a2_t = _helpers.to_tensors(a1, a2)
-    try:
-        a1_t, a2_t = torch.broadcast_tensors(a1_t, a2_t)
-    except RuntimeError:
-        # failed to broadcast => not equivalent
-        return False
-    return _impl.tensor_equal(a1_t, a2_t)
+    result = _impl.tensor_equiv(a1_t, a2_t)
+    return result
 
 
 def common_type():

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -498,10 +498,7 @@ def bincount(x, /, weights=None, minlength=0):
         x = asarray([], dtype=int)
 
     x_tensor, weights_tensor = _helpers.to_tensors_or_none(x, weights)
-    int_dtype = _dtypes_impl.default_int_dtype
-    (x_tensor,) = _util.cast_dont_broadcast((x_tensor,), int_dtype, casting="safe")
-
-    result = torch.bincount(x_tensor, weights_tensor, minlength)
+    result = _impl.bincount(x_tensor, weights_tensor, minlength)
     return asarray(result)
 
 

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -1025,10 +1025,8 @@ def argsort(a, axis=-1, kind=None, order=None):
 
 @asarray_replacer()
 def angle(z, deg=False):
-    result = torch.angle(z)
-    if deg:
-        result *= 180 / torch.pi
-    return asarray(result)
+    result = _impl.tensor_angle(z, deg)
+    return result
 
 
 @asarray_replacer()
@@ -1048,28 +1046,20 @@ def imag(a):
 
 @asarray_replacer()
 def real_if_close(a, tol=100):
-    if not torch.is_complex(a):
-        return a
-    if torch.abs(torch.imag) < tol * torch.finfo(a.dtype).eps:
-        return torch.real(a)
-    else:
-        return a
+    result = _impl.tensor_real_if_close(a, tol=tol)
+    return result
 
 
 @asarray_replacer()
 def iscomplex(x):
-    if torch.is_complex(x):
-        return torch.as_tensor(x).imag != 0
-    result = torch.zeros_like(x, dtype=torch.bool)
-    return result[()]
+    result = _impl.tensor_iscomplex(x)
+    return result  # XXX: missing .item on a zero-dim value; a case for array_or_scalar(value) ?
 
 
 @asarray_replacer()
 def isreal(x):
-    if torch.is_complex(x):
-        return torch.as_tensor(x).imag == 0
-    result = torch.zeros_like(x, dtype=torch.bool)
-    return result[()]
+    result = _impl.tensor_isreal(x)
+    return result
 
 
 @asarray_replacer()

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -176,56 +176,35 @@ def stack(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
 def array_split(ary, indices_or_sections, axis=0):
     tensor = asarray(ary).get()
     base = ary if isinstance(ary, ndarray) else None
-    axis = _util.normalize_axis_index(axis, tensor.ndim)
-
     result = _impl.split_helper(tensor, indices_or_sections, axis)
-
     return tuple(maybe_set_base(x, base) for x in result)
 
 
 def split(ary, indices_or_sections, axis=0):
     tensor = asarray(ary).get()
     base = ary if isinstance(ary, ndarray) else None
-    axis = _util.normalize_axis_index(axis, tensor.ndim)
-
     result = _impl.split_helper(tensor, indices_or_sections, axis, strict=True)
-
     return tuple(maybe_set_base(x, base) for x in result)
 
 
 def hsplit(ary, indices_or_sections):
     tensor = asarray(ary).get()
     base = ary if isinstance(ary, ndarray) else None
-
-    if tensor.ndim == 0:
-        raise ValueError("hsplit only works on arrays of 1 or more dimensions")
-
-    axis = 1 if tensor.ndim > 1 else 0
-
-    result = _impl.split_helper(tensor, indices_or_sections, axis, strict=True)
-
+    result = _impl.hsplit(tensor, indices_or_sections)
     return tuple(maybe_set_base(x, base) for x in result)
 
 
 def vsplit(ary, indices_or_sections):
     tensor = asarray(ary).get()
     base = ary if isinstance(ary, ndarray) else None
-
-    if tensor.ndim < 2:
-        raise ValueError("vsplit only works on arrays of 2 or more dimensions")
-    result = _impl.split_helper(tensor, indices_or_sections, 0, strict=True)
-
+    result = _impl.vsplit(tensor, indices_or_sections)
     return tuple(maybe_set_base(x, base) for x in result)
 
 
 def dsplit(ary, indices_or_sections):
     tensor = asarray(ary).get()
     base = ary if isinstance(ary, ndarray) else None
-
-    if tensor.ndim < 3:
-        raise ValueError("dsplit only works on arrays of 3 or more dimensions")
-    result = _impl.split_helper(tensor, indices_or_sections, 2, strict=True)
-
+    result = _impl.dsplit(tensor, indices_or_sections)
     return tuple(maybe_set_base(x, base) for x in result)
 
 

--- a/torch_np/tests/numpy_tests/lib/test_type_check.py
+++ b/torch_np/tests/numpy_tests/lib/test_type_check.py
@@ -82,7 +82,7 @@ class TestMintypecode:
         assert_equal(mintypecode('idD'), 'D')
 
 
-@pytest.mark.xfail(reason="not implemented")
+@pytest.mark.xfail(reason="TODO: decide on if [1] is a scalar or not")
 class TestIsscalar:
 
     def test_basic(self):
@@ -188,7 +188,6 @@ class TestIsreal:
         assert res.all()
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIscomplexobj:
 
     def test_basic(self):
@@ -206,7 +205,7 @@ class TestIscomplexobj:
         assert_(not iscomplexobj([3, 1, True]))
 
 
-@pytest.mark.xfail(reason="not implemented")
+
 class TestIsrealobj:
     def test_basic(self):
         z = np.array([-1, 0, 1])
@@ -215,7 +214,6 @@ class TestIsrealobj:
         assert_(not isrealobj(z))
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIsnan:
 
     def test_goodvalues(self):
@@ -246,7 +244,6 @@ class TestIsnan:
             assert_all(np.isnan(np.array(0+0j)/0.) == 1)
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIsfinite:
     # Fixme, wrong place, isfinite now ufunc
 
@@ -278,7 +275,6 @@ class TestIsfinite:
             assert_all(np.isfinite(np.array(1+1j)/0.) == 0)
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIsinf:
     # Fixme, wrong place, isinf now ufunc
 
@@ -308,7 +304,6 @@ class TestIsinf:
             assert_all(np.isinf(np.array((0.,))/0.) == 0)
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIsposinf:
 
     def test_generic(self):
@@ -319,7 +314,6 @@ class TestIsposinf:
         assert_(vals[2] == 1)
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIsneginf:
 
     def test_generic(self):
@@ -436,7 +430,6 @@ class TestNanToNum:
         assert_equal(type(vals), np.ndarray)
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestRealIfClose:
 
     def test_basic(self):

--- a/torch_np/tests/numpy_tests/lib/test_type_check.py
+++ b/torch_np/tests/numpy_tests/lib/test_type_check.py
@@ -157,7 +157,6 @@ class TestImag:
         assert_(not isinstance(out, np.ndarray))
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIscomplex:
 
     def test_fail(self):
@@ -171,7 +170,6 @@ class TestIscomplex:
         assert_array_equal(res, [1, 0, 0])
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestIsreal:
 
     def test_pass(self):
@@ -183,6 +181,11 @@ class TestIsreal:
         z = np.array([-1j, 1, 0])
         res = isreal(z)
         assert_array_equal(res, [0, 1, 1])
+
+    def test_isreal_real(self):
+        z = np.array([-1, 0, 1])
+        res = isreal(z)
+        assert res.all()
 
 
 @pytest.mark.xfail(reason="not implemented")
@@ -201,42 +204,6 @@ class TestIscomplexobj:
     def test_list(self):
         assert_(iscomplexobj([3, 1+0j, True]))
         assert_(not iscomplexobj([3, 1, True]))
-
-    def test_duck(self):
-        class DummyComplexArray:
-            @property
-            def dtype(self):
-                return np.dtype(complex)
-        dummy = DummyComplexArray()
-        assert_(iscomplexobj(dummy))
-
-    def test_pandas_duck(self):
-        # This tests a custom np.dtype duck-typed class, such as used by pandas
-        # (pandas.core.dtypes)
-        class PdComplex(np.complex128):
-            pass
-        class PdDtype:
-            name = 'category'
-            names = None
-            type = PdComplex
-            kind = 'c'
-            str = '<c16'
-            base = np.dtype('complex128')
-        class DummyPd:
-            @property
-            def dtype(self):
-                return PdDtype
-        dummy = DummyPd()
-        assert_(iscomplexobj(dummy))
-
-    def test_custom_dtype_duck(self):
-        class MyArray(list):
-            @property
-            def dtype(self):
-                return complex
-
-        a = MyArray([1+0j, 2+0j, 3+0j])
-        assert_(iscomplexobj(a))
 
 
 @pytest.mark.xfail(reason="not implemented")


### PR DESCRIPTION
Working towards moving actual logic to `_detail`, so that top level modules (currently, _wrappers.py, _ndarray.py) unwrap/normalize their inputs and pass heavy lifting to `_detail`. Details of organization of the `_detail` submodules are TBD, and so are details of unwrapping/normalization or arguments. This PR is to only to make the split as clean as reasonable.  