### PR TITLE
CI: use pytest-xdist with 2 cores on GHA

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -41,7 +41,7 @@ jobs:
           conda config --add channels conda-forge
           conda config --set channel_priority strict
           conda info
-          conda install python==3.9 pytorch==1.13.0 pytest numpy hypothesis -y
+          conda install python==3.9 pytorch==1.13.0 pytest pytest-xdist numpy hypothesis -y
           conda list
           conda config --show-sources
       #    conda config --show
@@ -50,5 +50,5 @@ jobs:
           ls -l
       - name: Run tests
         run: |
-          pytest torch_np/ -v -s
+          pytest torch_np/ -v -s -n 2
 


### PR DESCRIPTION
IIUC, GH hosted runners have two cores (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners), so use them.