### PR TITLE
Run test CI on pushes for any branch and PR activity

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -3,11 +3,7 @@
 
 name: dev
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 jobs:
   example-4:
     name: test


### PR DESCRIPTION
Currently our test CI only runs for `main` changes, so it'd be nice to get it running for any other branches, and when folks open/push-to PRs generally.