### PR TITLE
`@pytest.mark.slow` and `--runslow` option

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -46,5 +46,5 @@ jobs:
           ls -l
       - name: Run tests
         run: |
-          pytest torch_np/ -v -s -n 2
+          pytest torch_np/ -v -s -n 2 --runslow
 

--- a/torch_np/tests/conftest.py
+++ b/torch_np/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: very slow tests")
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true", help="run slow tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--runslow"):
+        skip_slow = pytest.mark.skip(reason="slow test, use --runslow to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)


### PR DESCRIPTION
* Skips any test with the `pytest.mark.slow` marker by default like in NumPy
* Introduces `--runslow` option to run these slow tests
* Uses `--runslow` on our test CI