### PR TITLE
Add ndarray.dot

### DIFF
--- a/torch_np/_detail/_ufunc_impl.py
+++ b/torch_np/_detail/_ufunc_impl.py
@@ -1,6 +1,7 @@
 import torch
 
 from . import _util
+from . import _dtypes_impl
 
 
 def deco_ufunc(torch_func):
@@ -70,7 +71,6 @@ logaddexp2 = deco_ufunc(torch.logaddexp2)
 logical_and = deco_ufunc(torch.logical_and)
 logical_or = deco_ufunc(torch.logical_or)
 logical_xor = deco_ufunc(torch.logical_xor)
-matmul = deco_ufunc(torch.matmul)
 maximum = deco_ufunc(torch.maximum)
 minimum = deco_ufunc(torch.minimum)
 remainder = deco_ufunc(torch.remainder)
@@ -143,7 +143,15 @@ def _absolute(x):
         return x
     return torch.absolute(x)
 
+def _matmul(x, y):
+    # work around RuntimeError: expected scalar type Int but found Double
+    dtype = _dtypes_impl.result_type_impl((x.dtype, y.dtype))
+    x = x.to(dtype)
+    y = y.to(dtype)
+    result = torch.matmul(x, y)
+    return result
 
 cbrt = deco_ufunc(_cbrt)
 positive = deco_ufunc(_positive)
 absolute = deco_ufunc(_absolute)
+matmul = deco_ufunc(_matmul)

--- a/torch_np/_detail/_ufunc_impl.py
+++ b/torch_np/_detail/_ufunc_impl.py
@@ -1,7 +1,6 @@
 import torch
 
-from . import _util
-from . import _dtypes_impl
+from . import _dtypes_impl, _util
 
 
 def deco_ufunc(torch_func):
@@ -143,6 +142,7 @@ def _absolute(x):
         return x
     return torch.absolute(x)
 
+
 def _matmul(x, y):
     # work around RuntimeError: expected scalar type Int but found Double
     dtype = _dtypes_impl.result_type_impl((x.dtype, y.dtype))
@@ -150,6 +150,7 @@ def _matmul(x, y):
     y = y.to(dtype)
     result = torch.matmul(x, y)
     return result
+
 
 cbrt = deco_ufunc(_cbrt)
 positive = deco_ufunc(_positive)

--- a/torch_np/_detail/_ufunc_impl.py
+++ b/torch_np/_detail/_ufunc_impl.py
@@ -146,8 +146,8 @@ def _absolute(x):
 def _matmul(x, y):
     # work around RuntimeError: expected scalar type Int but found Double
     dtype = _dtypes_impl.result_type_impl((x.dtype, y.dtype))
-    x = x.to(dtype)
-    y = y.to(dtype)
+    x = _util.cast_if_needed(x, dtype)
+    y = _util.cast_if_needed(y, dtype)
     result = torch.matmul(x, y)
     return result
 

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -507,7 +507,7 @@ def arange(start=None, stop=None, step=1, dtype=None):
 
     if (step > 0 and start > stop) or (step < 0 and start < stop):
         # empty range
-        return torch.as_tensor([], dtype=target_dtype)
+        return torch.empty(0, dtype=target_type)
 
     try:
         result = torch.arange(start, stop, step, dtype=work_dtype)

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -507,7 +507,7 @@ def arange(start=None, stop=None, step=1, dtype=None):
 
     if (step > 0 and start > stop) or (step < 0 and start < stop):
         # empty range
-        return torch.empty(0, dtype=target_type)
+        return torch.empty(0, dtype=target_dtype)
 
     try:
         result = torch.arange(start, stop, step, dtype=work_dtype)
@@ -797,6 +797,10 @@ def vdot(t_a, t_b, /):
 
 
 def dot(t_a, t_b):
+    dtype = _dtypes_impl.result_type_impl((t_a.dtype, t_b.dtype))
+    t_a = _util.cast_if_needed(t_a, dtype)
+    t_b = _util.cast_if_needed(t_b, dtype)
+
     if t_a.ndim == 0 or t_b.ndim == 0:
         result = t_a * t_b
     elif t_a.ndim == 1 and t_b.ndim == 1:

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -178,8 +178,6 @@ def trace(tensor, offset=0, axis1=0, axis2=1, dtype=None, out=None):
 def diagonal(tensor, offset=0, axis1=0, axis2=1):
     axis1 = _util.normalize_axis_index(axis1, tensor.ndim)
     axis2 = _util.normalize_axis_index(axis2, tensor.ndim)
-    if axis1 == axis2:
-        raise ValueError("axis1 and axis2 cannot be the same")
     result = torch.diagonal(tensor, offset, axis1, axis2)
     return result
 
@@ -494,25 +492,31 @@ def arange(start=None, stop=None, step=1, dtype=None):
     if start is None:
         start = 0
 
-#    if dtype is None:
+    # the dtype of the result
+    if dtype is None:
+        dtype = _dtypes_impl.default_int_dtype
     dt_list = [_util._coerce_to_tensor(x).dtype for x in (start, stop, step)]
-    dtype = _dtypes_impl.default_int_dtype
     dt_list.append(dtype)
     dtype = _dtypes_impl.result_type_impl(dt_list)
 
-    # work around RuntimeError: "arange_cpu" not implemented for 'ComplexFloat'        
-    orig_dtype = dtype
-    is_complex = dtype is not None and dtype.is_complex
+    # work around RuntimeError: "arange_cpu" not implemented for 'ComplexFloat'
+    if dtype.is_complex:
+        work_dtype, target_dtype = torch.float64, dtype
+    else:
+        work_dtype, target_dtype = dtype, dtype
+
+    if (step > 0 and start > stop) or (step < 0 and start < stop):
+        # empty range
+        return torch.as_tensor([], dtype=target_dtype)
+
     try:
-        if is_complex:
-            dtype = torch.float64
-        result = torch.arange(start, stop, step, dtype=orig_dtype)
-        if is_complex:
-            result  = result.to(dttype)
+        result = torch.arange(start, stop, step, dtype=work_dtype)
+        result = _util.cast_if_needed(result, target_dtype)
     except RuntimeError:
         raise ValueError("Maximum allowed size exceeded")
 
     return result
+
 
 # ### empty/full et al ###
 

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -1,7 +1,7 @@
 import torch
 
 from . import _decorators, _helpers
-from ._detail import _flips, _util
+from ._detail import _flips, _util, _dtypes_impl
 from ._detail import implementations as _impl
 
 
@@ -101,6 +101,9 @@ def vdot(a, b, /):
 
 def dot(a, b, out=None):
     t_a, t_b = _helpers.to_tensors(a, b)
+    dtype = _dtypes_impl.result_type_impl((t_a.dtype, t_b.dtype))
+    t_a = t_a.to(dtype)
+    t_b = t_b.to(dtype)
     result = _impl.dot(t_a, t_b)
     return _helpers.result_or_out(result, out)
 

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -101,9 +101,6 @@ def vdot(a, b, /):
 
 def dot(a, b, out=None):
     t_a, t_b = _helpers.to_tensors(a, b)
-    dtype = _dtypes_impl.result_type_impl((t_a.dtype, t_b.dtype))
-    t_a = t_a.to(dtype)
-    t_b = t_b.to(dtype)
     result = _impl.dot(t_a, t_b)
     return _helpers.result_or_out(result, out)
 

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -93,7 +93,18 @@ def fill_diagonal(a, val, wrap=False):
     return _helpers.array_from(result)
 
 
-# ### sorting ###
+def vdot(a, b, /):
+    t_a, t_b = _helpers.to_tensors(a, b)
+    result = _impl.vdot(t_a, t_b)
+    return result.item()
+
+
+def dot(a, b, out=None):
+    t_a, t_b = _helpers.to_tensors(a, b)
+    result = _impl.dot(t_a, t_b)
+    return _helpers.result_or_out(result, out)
+
+
 
 # ### sort and partition ###
 

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -1,7 +1,7 @@
 import torch
 
 from . import _decorators, _helpers
-from ._detail import _flips, _util, _dtypes_impl
+from ._detail import _dtypes_impl, _flips, _util
 from ._detail import implementations as _impl
 
 
@@ -106,7 +106,6 @@ def dot(a, b, out=None):
     t_b = t_b.to(dtype)
     result = _impl.dot(t_a, t_b)
     return _helpers.result_or_out(result, out)
-
 
 
 # ### sort and partition ###

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -362,6 +362,7 @@ class ndarray:
 
     diagonal = _funcs.diagonal
     trace = _funcs.trace
+    dot = _funcs.dot
 
     ### sorting ###
 

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -421,7 +421,6 @@ def where(condition, x=None, y=None, /):
         return asarray(result)
 
 
-
 ###### module-level queries of object properties
 
 

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -421,17 +421,6 @@ def where(condition, x=None, y=None, /):
         return asarray(result)
 
 
-def vdot(a, b, /):
-    t_a, t_b = _helpers.to_tensors(a, b)
-    result = _impl.vdot(t_a, t_b)
-    return result.item()
-
-
-def dot(a, b, out=None):
-    t_a, t_b = _helpers.to_tensors(a, b)
-    result = _impl.dot(t_a, t_b)
-    return _helpers.result_or_out(result, out)
-
 
 ###### module-level queries of object properties
 

--- a/torch_np/tests/numpy_tests/core/test_multiarray.py
+++ b/torch_np/tests/numpy_tests/core/test_multiarray.py
@@ -2468,7 +2468,6 @@ class TestMethods:
                 func(edf, edf[:, ::-1].T.copy())
             )
 
-    @pytest.mark.xfail(reason="TODO np.dot")
     @pytest.mark.parametrize('func', (np.dot, np.matmul))
     @pytest.mark.parametrize('dtype', 'ifdFD')
     def test_no_dgemv(self, func, dtype):


### PR DESCRIPTION
Now that both np.dot and ndarray.dot are there, can remove xfails in tests. Which, in turn, smokes out several problems in arange(..., dtype=complex), so fix them. And while at it, remove xfails of TestArange itself and fix it, too :-)