### PR TITLE
Introduce `--nonp` to error when NumPy is accessed

### DIFF
--- a/torch_np/tests/conftest.py
+++ b/torch_np/tests/conftest.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 
@@ -7,6 +9,17 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", help="run slow tests")
+    parser.addoption("--nonp", action="store_true", help="error when NumPy is accessed")
+
+
+def pytest_sessionstart(session):
+    if session.config.getoption("--nonp"):
+
+        class Inaccessible:
+            def __getattribute__(self, attr):
+                raise RuntimeError(f"Using --nonp but accessed np.{attr}")
+
+        sys.modules["numpy"] = Inaccessible()
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
Using `--nonp` will error before any tests are run when NumPy is accessed. I think this is especially useful as we can use it iteratively—
```console
$ cat torch_np/tests/test_foo.py
def test_foo:
    assert True
$ pytest torch_np/tests/test_foo.py
# no error
```

No error is raised because the tests pytest has collected never import NumPy. Meanwhile 

```console
$ cat torch_np/_uses_numpy.py
import numpy as np
...
np.int8
...
$ cat torch_np/tests/test_bar.py
from torch_np import _uses_numpy
$ pytest torch_np/tests/test_bar.py
...
ERROR torch_np/tests/test_bar.py - RuntimeError: Using --nonp but accessed np.int8
    torch_np/tests/test_bar.py:1: in <module>
        ???
    torch_np/_uses_numpy.py:4: in <module>
        ???
    torch_np/tests/conftest.py:20: in __getattribute__
        ???
    E   RuntimeError: Using --nonp but accessed np.int8
...
ERROR torch_np/tests/test_bar.py - RuntimeError: Using --nonp but accessed np.int8
```

i.e. only when the test ends up having NumPy imported does it error on the collection stage. This means we can leverage the coverage of individual test files and work on getting those passing before jumping on to another, til eventually just `pytest torch_np/tests/ --nonp` passes (and then we can introduce a CI job for it to prevent regressions).