### PR TITLE
MAINT: split remaining functions into normalizations and implementations

### DIFF
--- a/torch_np/_detail/_reductions.py
+++ b/torch_np/_detail/_reductions.py
@@ -375,7 +375,24 @@ def average_weights(a_tensor, axis, w_tensor, keepdims=False):
     return result, denominator
 
 
-def quantile(a_tensor, q_tensor, axis, method, keepdims=False):
+def quantile(
+    a_tensor,
+    q_tensor,
+    axis,
+    overwrite_input,
+    method,
+    keepdims=False,
+    interpolation=None,
+):
+    if overwrite_input:
+        # raise NotImplementedError("overwrite_input in quantile not implemented.")
+        # NumPy documents that `overwrite_input` MAY modify inputs:
+        # https://numpy.org/doc/stable/reference/generated/numpy.percentile.html#numpy-percentile
+        # Here we choose to work out-of-place because why not.
+        pass
+
+    if interpolation is not None:
+        raise ValueError("'interpolation' argument is deprecated; use 'method' instead")
 
     if (0 > q_tensor).any() or (q_tensor > 1).any():
         raise ValueError("Quantiles must be in range [0, 1], got %s" % q_tensor)
@@ -408,3 +425,23 @@ def quantile(a_tensor, q_tensor, axis, method, keepdims=False):
     if keepdims:
         result = _util.apply_keepdims(result, ax, ndim)
     return result
+
+
+def percentile(
+    a_tensor,
+    q_tensor,
+    axis,
+    overwrite_input,
+    method,
+    keepdims=False,
+    interpolation=None,
+):
+    return quantile(
+        a_tensor,
+        q_tensor / 100.0,
+        axis=axis,
+        overwrite_input=overwrite_input,
+        method=method,
+        keepdims=keepdims,
+        interpolation=interpolation,
+    )

--- a/torch_np/_detail/_reductions.py
+++ b/torch_np/_detail/_reductions.py
@@ -390,9 +390,6 @@ def quantile(
     if interpolation is not None:
         raise ValueError("'interpolation' argument is deprecated; use 'method' instead")
 
-    if (0 > q).any() or (q > 1).any():
-        raise ValueError("Quantiles must be in range [0, 1], got %s" % q)
-
     if not a.dtype.is_floating_point:
         dtype = _dtypes_impl.default_float_dtype
         a = a.to(dtype)

--- a/torch_np/_detail/implementations.py
+++ b/torch_np/_detail/implementations.py
@@ -461,15 +461,15 @@ def indices(dimensions, dtype=int, sparse=False):
     return res
 
 
-def bincount(x_tensor, /, weights_tensor=None, minlength=0):
-    if x_tensor.numel() == 0:
+def bincount(x, /, weights=None, minlength=0):
+    if x.numel() == 0:
         # edge case allowed by numpy
-        x_tensor = torch.as_tensor([], dtype=int)
+        x = x.new_empty(0, dtype=int)
 
     int_dtype = _dtypes_impl.default_int_dtype
-    (x_tensor,) = _util.cast_dont_broadcast((x_tensor,), int_dtype, casting="safe")
+    (x,) = _util.cast_dont_broadcast((x,), int_dtype, casting="safe")
 
-    result = torch.bincount(x_tensor, weights_tensor, minlength)
+    result = torch.bincount(x, weights, minlength)
     return result
 
 

--- a/torch_np/_normalizations.py
+++ b/torch_np/_normalizations.py
@@ -104,7 +104,9 @@ def normalizer(_func=None, *, return_on_failure=_sentinel):
             first_param = next(iter(params.values()))
             # NumPy's API does not have positional args before variadic positional args
             if first_param.kind == inspect.Parameter.VAR_POSITIONAL:
-                args = [maybe_normalize(arg, first_param, return_on_failure) for arg in args]
+                args = [
+                    maybe_normalize(arg, first_param, return_on_failure) for arg in args
+                ]
             else:
                 # NB: extra unknown arguments: pass through, will raise in func(*args) below
                 args = (
@@ -120,10 +122,10 @@ def normalizer(_func=None, *, return_on_failure=_sentinel):
                 for name, arg in kwds.items()
             }
             return func(*args, **kwds)
+
         return wrapped
 
     if _func is None:
         return normalizer_inner
     else:
         return normalizer_inner(_func)
-

--- a/torch_np/_wrapper.py
+++ b/torch_np/_wrapper.py
@@ -775,15 +775,12 @@ def i0(x: ArrayLike):
     return _helpers.array_from(result)
 
 
-def isscalar(a):
+@normalizer(return_on_failure=False)
+def isscalar(a: ArrayLike):
     # XXX: this is a stub
-    try:
-        from ._ndarray import asarray
-
-        t = asarray(a).get()
-        return t.numel() == 1
-    except Exception:
-        return False
+    if a is False:
+        return a
+    return a.numel() == 1
 
 
 @normalizer

--- a/torch_np/tests/numpy_tests/lib/test_function_base.py
+++ b/torch_np/tests/numpy_tests/lib/test_function_base.py
@@ -2900,10 +2900,10 @@ class TestPercentile:
     def test_exception(self):
         assert_raises((RuntimeError, ValueError), np.percentile, [1, 2], 56,
                       method='foobar')
-        assert_raises(ValueError, np.percentile, [1], 101)
-        assert_raises(ValueError, np.percentile, [1], -1)
-        assert_raises(ValueError, np.percentile, [1], list(range(50)) + [101])
-        assert_raises(ValueError, np.percentile, [1], list(range(50)) + [-0.1])
+        assert_raises((RuntimeError, ValueError), np.percentile, [1], 101)
+        assert_raises((RuntimeError, ValueError), np.percentile, [1], -1)
+        assert_raises((RuntimeError, ValueError), np.percentile, [1], list(range(50)) + [101])
+        assert_raises((RuntimeError, ValueError), np.percentile, [1], list(range(50)) + [-0.1])
 
     def test_percentile_list(self):
         assert_equal(np.percentile([1, 2, 3], 0), 1)


### PR DESCRIPTION
This finishes up the move of all work to be done on the torch level in `detail`, and the wrappers are as thin as it gets AFAICS. 