### PR TITLE
ENH: add a naive divmod, un-xfail relevant tests

### DIFF
--- a/torch_np/_binary_ufuncs.py
+++ b/torch_np/_binary_ufuncs.py
@@ -57,3 +57,58 @@ for name in __all__:
     decorated.__qualname__ = name  # XXX: is this really correct?
     decorated.__name__ = name
     vars()[name] = decorated
+
+
+# a stub implementation of divmod, should be improved after
+# https://github.com/pytorch/pytorch/issues/90820 is fixed in pytorch
+#
+# Implementation details: we just call two ufuncs which have been created
+# just above, for x1 // x2 and x1 % x2.
+# This means we are normalizing x1, x2 in each of the ufuncs --- note that there
+# is no @normalizer on divmod.
+
+
+def divmod(
+    x1,
+    x2,
+    /,
+    out=None,
+    *,
+    where=True,
+    casting="same_kind",
+    order="K",
+    dtype=None,
+    subok: SubokLike = False,
+    signature=None,
+    extobj=None,
+):
+    out1, out2 = None, None
+    if out is not None:
+        out1, out2 = out
+
+    kwds = dict(
+        where=where,
+        casting=casting,
+        order=order,
+        dtype=dtype,
+        subok=subok,
+        signature=signature,
+        extobj=extobj,
+    )
+
+    # NB: use local names for
+    quot = floor_divide(x1, x2, out=out1, **kwds)
+    rem = remainder(x1, x2, out=out2, **kwds)
+
+    quot = _helpers.result_or_out(quot.get(), out1)  # FIXME: .get() -> .tensor
+    rem = _helpers.result_or_out(rem.get(), out2)
+
+    return quot, rem
+
+
+def modf(x, /, *args, **kwds):
+    quot, rem = divmod(x, 1, *args, **kwds)
+    return rem, quot
+
+
+__all__ = __all__ + ["divmod", "modf"]

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -272,6 +272,8 @@ class ndarray:
     def __ifloordiv__(self, other):
         return _binary_ufuncs.floor_divide(self, other, out=self)
 
+    __divmod__ = _binary_ufuncs.divmod
+
     # power, self**exponent
     __pow__ = __rpow__ = _binary_ufuncs.float_power
 

--- a/torch_np/_normalizations.py
+++ b/torch_np/_normalizations.py
@@ -50,7 +50,7 @@ def normalize_dtype(dtype, name=None):
     return torch_dtype
 
 
-def normalize_subok_like(arg, name):
+def normalize_subok_like(arg, name="subok"):
     if arg:
         raise ValueError(f"'{name}' parameter is not supported.")
 
@@ -94,7 +94,7 @@ def normalize_this(arg, parm, return_on_failure=_sentinel):
     normalizer = normalizers.get(parm.annotation, None)
     if normalizer:
         try:
-            return normalizer(arg)
+            return normalizer(arg, parm.name)
         except Exception as exc:
             if return_on_failure is not _sentinel:
                 return return_on_failure


### PR DESCRIPTION
Implement `np.divmod(x1, x2)` and `ndarray.__divmod__`. These are unusual in that they allow two output arrays, so it's either complicate and obfuscate the ufunc machinery just for these two, or special case. This PR opts for the latter :-).

Since there is no pytorch-native divmod (cf https://github.com/pytorch/pytorch/issues/90820 ), this PR just does `(x1 // x2, x1 % x2)` in the wrapper level.  

This PR is on top of gh-83, for clarity.