### PR TITLE
add torch_np.linalg module

### DIFF
--- a/torch_np/__init__.py
+++ b/torch_np/__init__.py
@@ -6,6 +6,7 @@ from ._funcs import *
 from ._getlimits import errstate, finfo, iinfo
 from ._ndarray import array, asarray, can_cast, ndarray, newaxis, result_type
 from ._unary_ufuncs import *
+from . import linalg
 
 # from . import testing
 

--- a/torch_np/__init__.py
+++ b/torch_np/__init__.py
@@ -1,4 +1,4 @@
-from . import random
+from . import linalg, random
 from ._binary_ufuncs import *
 from ._detail._util import AxisError, UFuncTypeError
 from ._dtypes import *
@@ -6,7 +6,6 @@ from ._funcs import *
 from ._getlimits import errstate, finfo, iinfo
 from ._ndarray import array, asarray, can_cast, ndarray, newaxis, result_type
 from ._unary_ufuncs import *
-from . import linalg
 
 # from . import testing
 

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -1911,19 +1911,23 @@ def bartlett(M):
     return torch.bartlett_window(M, periodic=False, dtype=dtype)
 
 
-
 # ### Dtype routines ###
 
 # vendored from https://github.com/numpy/numpy/blob/v1.24.0/numpy/lib/type_check.py#L666
 
 
-array_type = [[torch.float16, torch.float32, torch.float64],
-              [None, torch.complex64, torch.complex128]]
-array_precision = {torch.float16: 0,
-                   torch.float32: 1,
-                   torch.float64: 2,
-                   torch.complex64: 1,
-                   torch.complex128: 2,}
+array_type = [
+    [torch.float16, torch.float32, torch.float64],
+    [None, torch.complex64, torch.complex128],
+]
+array_precision = {
+    torch.float16: 0,
+    torch.float32: 1,
+    torch.float64: 2,
+    torch.complex64: 1,
+    torch.complex128: 2,
+}
+
 
 @normalizer
 def common_type(*tensors: ArrayLike):
@@ -1936,7 +1940,7 @@ def common_type(*tensors: ArrayLike):
         t = a.dtype
         if iscomplexobj(a):
             is_complex = True
-        if not(t.is_floating_point or t.is_complex):
+        if not (t.is_floating_point or t.is_complex):
             p = 2  # array_precision[_nx.double]
         else:
             p = array_precision.get(t, None)
@@ -1947,5 +1951,3 @@ def common_type(*tensors: ArrayLike):
         return array_type[1][precision]
     else:
         return array_type[0][precision]
-
-

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -1358,9 +1358,12 @@ def reshape(a: ArrayLike, newshape, order="C"):
 @normalizer
 def transpose(a: ArrayLike, axes=None):
     # numpy allows both .tranpose(sh) and .transpose(*sh)
-    axes = axes[0] if len(axes) == 1 else axes
+    # also older code uses axes being a list
     if axes in [(), None, (None,)]:
         axes = tuple(range(a.ndim))[::-1]
+    elif len(axes) == 1:
+        axes = axes[0]
+
     try:
         result = a.permute(axes)
     except RuntimeError:

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -911,10 +911,6 @@ def array_equiv(a1: ArrayLike, a2: ArrayLike):
     return _tensor_equal(a1_t, a2_t)
 
 
-def common_type():
-    raise NotImplementedError
-
-
 def mintypecode():
     raise NotImplementedError
 
@@ -1913,3 +1909,43 @@ def blackman(M):
 def bartlett(M):
     dtype = _dtypes_impl.default_float_dtype
     return torch.bartlett_window(M, periodic=False, dtype=dtype)
+
+
+
+# ### Dtype routines ###
+
+# vendored from https://github.com/numpy/numpy/blob/v1.24.0/numpy/lib/type_check.py#L666
+
+
+array_type = [[torch.float16, torch.float32, torch.float64],
+              [None, torch.complex64, torch.complex128]]
+array_precision = {torch.float16: 0,
+                   torch.float32: 1,
+                   torch.float64: 2,
+                   torch.complex64: 1,
+                   torch.complex128: 2,}
+
+@normalizer
+def common_type(*tensors: ArrayLike):
+
+    import builtins
+
+    is_complex = False
+    precision = 0
+    for a in tensors:
+        t = a.dtype
+        if iscomplexobj(a):
+            is_complex = True
+        if not(t.is_floating_point or t.is_complex):
+            p = 2  # array_precision[_nx.double]
+        else:
+            p = array_precision.get(t, None)
+            if p is None:
+                raise TypeError("can't get common type for non-numeric array")
+        precision = builtins.max(precision, p)
+    if is_complex:
+        return array_type[1][precision]
+    else:
+        return array_type[0][precision]
+
+

--- a/torch_np/_funcs.py
+++ b/torch_np/_funcs.py
@@ -927,6 +927,10 @@ def asfarray():
     raise NotImplementedError
 
 
+def block(*args, **kwds):
+    raise NotImplementedError
+
+
 # ### put/take_along_axis ###
 
 
@@ -1358,6 +1362,7 @@ def reshape(a: ArrayLike, newshape, order="C"):
 @normalizer
 def transpose(a: ArrayLike, axes=None):
     # numpy allows both .tranpose(sh) and .transpose(*sh)
+    axes = axes[0] if len(axes) == 1 else axes
     if axes in [(), None, (None,)]:
         axes = tuple(range(a.ndim))[::-1]
     try:

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -152,6 +152,14 @@ class ndarray:
         tensor = self.tensor.clone()
         return ndarray(tensor)
 
+    def view(self, dtype):
+        torch_dtype = _dtypes.dtype(dtype).torch_dtype
+        tview = self.tensor.view(torch_dtype)
+        return ndarray(tview)
+
+    def fill(self, value):
+        self.tensor.fill_(value)
+
     def tolist(self):
         return self.tensor.tolist()
 

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -43,7 +43,7 @@ def matrix_power(a: ArrayLike, n):
 
 
 @normalizer
-def multi_dot(inputs : Sequence[ArrayLike], *, out=None):
+def multi_dot(inputs: Sequence[ArrayLike], *, out=None):
     return torch.linalg.multi_dot(inputs)
 
 

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 import torch
 
 from ._detail import _dtypes_impl, _util
@@ -41,7 +43,7 @@ def matrix_power(a: ArrayLike, n):
 
 
 @normalizer
-def multi_dot(inputs, *, out=None):
+def multi_dot(inputs : Sequence[ArrayLike], *, out=None):
     return torch.linalg.multi_dot(inputs)
 
 
@@ -64,7 +66,11 @@ def lstsq(a: ArrayLike, b: ArrayLike, rcond=None):
 @normalizer
 def inv(a: ArrayLike):
     a = _atleast_float_1(a)
-    return torch.linalg.inv(a)
+    try:
+        result = torch.linalg.inv(a)
+    except torch._C._LinAlgError as e:
+        raise LinAlgError(*e.args)
+    return result
 
 
 @normalizer

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -1,0 +1,176 @@
+import torch
+
+from ._normalizations import ArrayLike, normalizer
+from ._detail import _dtypes_impl
+from ._detail import _util
+
+
+def _atleast_float_1(a):
+    if not (a.dtype.is_floating_point or a.dtype.is_complex):
+        a = a.to(_dtypes_impl.default_float_dtype)
+    return a
+
+
+def _atleast_float_2(a, b):
+    dtyp = _dtypes_impl._result_type_impl((a.dtype, b.dtype))    
+    if not (dtyp.is_floating_point or dtype.is_complex):
+        dtyp = _dtypes_impl.default_float_dtype
+
+    a = _util.cast_if_needed(a, dtyp)
+    b = _util.cast_if_needed(b, dtyp)
+    return a, b
+
+
+
+# ### Matrix and vector products ###
+
+@normalizer
+def matrix_power(a: ArrayLike, n):
+    a = _atleat_float_1(a)
+    return torch.linalg.matrix_power(a, n)
+
+
+@normalizer
+def multi_dot(inputs, *, out=None):
+    return torch.linalg.multi_dot(inputs)    
+
+
+# ### Solving equations and inverting matrices ###
+
+@normalizer
+def solve(a: ArrayLike, b: ArrayLike):
+    a, b = _atleast_float_2(a, b)
+    return torch.linalg.solve(a, b)
+
+
+@normalizer
+def lstsq(a: ArrayLike, b: ArrayLike, rcond=None):
+    a, b = _atleast_float_2(a, b)
+    # NumPy is using gelsd: https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/umath_linalg.cpp#L3991
+    return torch.linalg.lstsq(a, b, rcond=rcond, driver='gelsd')
+
+
+@normalizer
+def inv(a: ArrayLike):
+    a = _atleast_float_1(a)
+    return torch.linalg.inv(a)
+
+
+@normalizer
+def pinv(a: ArrayLike, rcond=1e-15, hermitian=False):
+    a = _atleast_float_1(a)
+    return torch.linalg.pinv(a, rtol=rcond, hermitian=hermitian)
+
+
+@normalizer
+def tensorsolve(a: ArrayLike, b: ArrayLike, axes=None):
+    a, b = _atleast_float_2(a, b)
+    return torch.linalg.tensorsolve(a, b, dims=axes)
+
+
+@normalizer
+def tensorinv(a: ArrayLike, ind=2):
+    a = _atleast_float_1(a)
+    return torch.linalg.tensorinv(a, ind=ind)
+
+
+# ### Norms and other numbers ###
+
+
+@normalizer
+def det(a: ArrayLike):
+    a = _atleast_float_1(a)
+    return torch.linalg.det(a)
+
+
+@normalizer
+def slogdet(a: ArrayLike):
+    a = _atleast_float_1(a)
+    return torch.linalg.slogdet(a)
+
+
+@normalizer
+def cond(a: ArrayLike, p):
+    a = _atleast_float_1(a)
+    return torch.linalg.cond(a, p=p)
+
+
+@normalizer
+def matrix_rank(a: ArrayLike, tol=None, hermitian=False):
+    a = _atleast_float_1(a)
+    if tol is None:
+        # follow https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/linalg.py#L1885
+        atol = 0
+        rtol = max(a.shape[-2:]) * tnp.finfo(a.dtype).eps
+    else:
+        atol, rtol = tol, 0
+    return torch.linalg.matrix_rank(a, atol=atol, rtol=rtol, hermitian=hermitian)
+
+
+
+@normalizer
+def norm(x: ArrayLike, ord=None, axis=None, keepdims=False):
+    x = _atleast_float_1(x)
+    result = torch.linalg.norm(x, ord=ord, dim=axis)
+    if keepdims:
+        result = _util.apply_keepdims(result, axis, tensor.ndim)
+    return result
+
+
+
+# ### Decompositions ###
+
+@normalizer
+def cholesky(a: ArrayLike):
+    a = _atleast_float_1(a)
+    return torch.linalg.cholesky(a)
+
+
+@normalizer
+def qr(a: ArrayLike, mode='reduced'):
+    a = _atleast_float_1(a)
+    result = torch.linalg.qr(a, mode=mode)
+    if mode == 'r':
+        # match NumPy
+        result = result.R
+    return result
+
+
+@normalizer
+def svd(a: ArrayLike, full_matrices=True, compute_uv=True, hermitian=False):
+    a = _atleast_float_1(a)
+    # NB: ignore the hermitian= argument (no pytorch equivalent)
+    result = torch.linalg.svd(a, full_matrices=full_matrices)
+    if not compute_uv:
+        result = result.S
+    return result
+
+
+# ### Eigenvalues and eigenvectors ###
+
+@normalizer
+def eig(a: ArrayLike):
+    a = _atleast_float_1(a)
+    return torch.linalg.eig(a)
+
+
+@normalizer
+def eigh(a: ArrayLike, UPLO='L'):
+    a = _atleast_float_1(a)
+    return torch.linalg.eigh(a, UPLO=UPLO)
+
+
+@normalizer
+def eigvals(a: ArrayLike):
+    a = _atleast_float_1(a)
+    return torch.linalg.eigvals(a)
+
+
+@normalizer
+def eigvalsh(a: ArrayLike, UPLO='L'):
+    a = _atleast_float_1(a)
+    return torch.linalg.eigvalsh(a, UPLO=UPLO)
+
+
+
+

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -1,3 +1,5 @@
+import functools
+import math
 from typing import Sequence
 
 import torch
@@ -26,23 +28,29 @@ def _atleast_float_2(a, b):
     return a, b
 
 
-def _prod(iterable):
-    p = 1.0
-    for x in iterable:
-        p *= x
-    return p
+def linalg_errors(func):
+    @functools.wraps(func)
+    def wrapped(*args, **kwds):
+        try:
+            return func(*args, **kwds)
+        except torch._C._LinAlgError as e:
+            raise LinAlgError(*e.args)
+
+    return wrapped
 
 
 # ### Matrix and vector products ###
 
 
 @normalizer
+@linalg_errors
 def matrix_power(a: ArrayLike, n):
     a = _atleat_float_1(a)
     return torch.linalg.matrix_power(a, n)
 
 
 @normalizer
+@linalg_errors
 def multi_dot(inputs: Sequence[ArrayLike], *, out=None):
     return torch.linalg.multi_dot(inputs)
 
@@ -51,41 +59,46 @@ def multi_dot(inputs: Sequence[ArrayLike], *, out=None):
 
 
 @normalizer
+@linalg_errors
 def solve(a: ArrayLike, b: ArrayLike):
     a, b = _atleast_float_2(a, b)
     return torch.linalg.solve(a, b)
 
 
 @normalizer
+@linalg_errors
 def lstsq(a: ArrayLike, b: ArrayLike, rcond=None):
     a, b = _atleast_float_2(a, b)
     # NumPy is using gelsd: https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/umath_linalg.cpp#L3991
-    return torch.linalg.lstsq(a, b, rcond=rcond, driver="gelsd")
+    # on CUDA, only `gels` is available though, so use it instead
+    driver = "gels" if a.is_cuda or b.is_cuda else "gelsd"
+    return torch.linalg.lstsq(a, b, rcond=rcond, driver=driver)
 
 
 @normalizer
+@linalg_errors
 def inv(a: ArrayLike):
     a = _atleast_float_1(a)
-    try:
-        result = torch.linalg.inv(a)
-    except torch._C._LinAlgError as e:
-        raise LinAlgError(*e.args)
+    result = torch.linalg.inv(a)
     return result
 
 
 @normalizer
+@linalg_errors
 def pinv(a: ArrayLike, rcond=1e-15, hermitian=False):
     a = _atleast_float_1(a)
     return torch.linalg.pinv(a, rtol=rcond, hermitian=hermitian)
 
 
 @normalizer
+@linalg_errors
 def tensorsolve(a: ArrayLike, b: ArrayLike, axes=None):
     a, b = _atleast_float_2(a, b)
     return torch.linalg.tensorsolve(a, b, dims=axes)
 
 
 @normalizer
+@linalg_errors
 def tensorinv(a: ArrayLike, ind=2):
     a = _atleast_float_1(a)
     return torch.linalg.tensorinv(a, ind=ind)
@@ -95,50 +108,44 @@ def tensorinv(a: ArrayLike, ind=2):
 
 
 @normalizer
+@linalg_errors
 def det(a: ArrayLike):
     a = _atleast_float_1(a)
     return torch.linalg.det(a)
 
 
 @normalizer
+@linalg_errors
 def slogdet(a: ArrayLike):
     a = _atleast_float_1(a)
     return torch.linalg.slogdet(a)
 
 
 @normalizer
+@linalg_errors
 def cond(x: ArrayLike, p=None):
     x = _atleast_float_1(x)
 
     # check if empty
     # cf: https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/linalg.py#L1744
-    if x.numel() == 0 and _prod(x.shape[-2:]) == 0:
+    if x.numel() == 0 and math.prod(x.shape[-2:]) == 0:
         raise LinAlgError("cond is not defined on empty arrays")
 
     result = torch.linalg.cond(x, p=p)
 
-    # Convert nans to infs unless the original array had nan entries
+    # Convert nans to infs (numpy does it in a data-dependent way, depending on
+    # whether the input array has nans or not)
     # XXX: NumPy does this: https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/linalg.py#L1744
-    # Do we want it? .any() synchronizes
-    """
-    nan_mask = torch.isnan(result)
-    if nan_mask.any():
-        nan_mask &= ~torch.isnan(x).any(axis=(-2, -1))  # XXX: any() w/ tuple axes
-        if result.ndim > 0:
-            result[nan_mask] = torch.inf
-        elif nan_mask:
-            result[()] = torch.inf
-    """
-
-    return result
+    return torch.where(torch.isnan(result), float("inf"), result)
 
 
 @normalizer
+@linalg_errors
 def matrix_rank(a: ArrayLike, tol=None, hermitian=False):
     a = _atleast_float_1(a)
 
     if a.ndim < 2:
-        return int(not (a == 0).all())
+        return int((a != 0).any())
 
     if tol is None:
         # follow https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/linalg.py#L1885
@@ -150,6 +157,7 @@ def matrix_rank(a: ArrayLike, tol=None, hermitian=False):
 
 
 @normalizer
+@linalg_errors
 def norm(x: ArrayLike, ord=None, axis=None, keepdims=False):
     x = _atleast_float_1(x)
     result = torch.linalg.norm(x, ord=ord, dim=axis)
@@ -162,12 +170,14 @@ def norm(x: ArrayLike, ord=None, axis=None, keepdims=False):
 
 
 @normalizer
+@linalg_errors
 def cholesky(a: ArrayLike):
     a = _atleast_float_1(a)
     return torch.linalg.cholesky(a)
 
 
 @normalizer
+@linalg_errors
 def qr(a: ArrayLike, mode="reduced"):
     a = _atleast_float_1(a)
     result = torch.linalg.qr(a, mode=mode)
@@ -178,12 +188,14 @@ def qr(a: ArrayLike, mode="reduced"):
 
 
 @normalizer
+@linalg_errors
 def svd(a: ArrayLike, full_matrices=True, compute_uv=True, hermitian=False):
     a = _atleast_float_1(a)
+    if not compute_uv:
+        return torch.linalg.svdvals(a)
+
     # NB: ignore the hermitian= argument (no pytorch equivalent)
     result = torch.linalg.svd(a, full_matrices=full_matrices)
-    if not compute_uv:
-        result = result.S
     return result
 
 
@@ -191,6 +203,7 @@ def svd(a: ArrayLike, full_matrices=True, compute_uv=True, hermitian=False):
 
 
 @normalizer
+@linalg_errors
 def eig(a: ArrayLike):
     a = _atleast_float_1(a)
     w, vt = torch.linalg.eig(a)
@@ -203,12 +216,14 @@ def eig(a: ArrayLike):
 
 
 @normalizer
+@linalg_errors
 def eigh(a: ArrayLike, UPLO="L"):
     a = _atleast_float_1(a)
     return torch.linalg.eigh(a, UPLO=UPLO)
 
 
 @normalizer
+@linalg_errors
 def eigvals(a: ArrayLike):
     a = _atleast_float_1(a)
     result = torch.linalg.eigvals(a)
@@ -219,6 +234,7 @@ def eigvals(a: ArrayLike):
 
 
 @normalizer
+@linalg_errors
 def eigvalsh(a: ArrayLike, UPLO="L"):
     a = _atleast_float_1(a)
     return torch.linalg.eigvalsh(a, UPLO=UPLO)

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -5,6 +5,10 @@ from ._detail import _dtypes_impl
 from ._detail import _util
 
 
+class LinAlgError(Exception):
+    pass
+
+
 def _atleast_float_1(a):
     if not (a.dtype.is_floating_point or a.dtype.is_complex):
         a = a.to(_dtypes_impl.default_float_dtype)

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -1,8 +1,7 @@
 import torch
 
+from ._detail import _dtypes_impl, _util
 from ._normalizations import ArrayLike, normalizer
-from ._detail import _dtypes_impl
-from ._detail import _util
 
 
 class LinAlgError(Exception):
@@ -16,8 +15,8 @@ def _atleast_float_1(a):
 
 
 def _atleast_float_2(a, b):
-    dtyp = _dtypes_impl._result_type_impl((a.dtype, b.dtype))    
-    if not (dtyp.is_floating_point or dtype.is_complex):
+    dtyp = _dtypes_impl.result_type_impl((a.dtype, b.dtype))
+    if not (dtyp.is_floating_point or dtyp.is_complex):
         dtyp = _dtypes_impl.default_float_dtype
 
     a = _util.cast_if_needed(a, dtyp)
@@ -25,8 +24,15 @@ def _atleast_float_2(a, b):
     return a, b
 
 
+def _prod(iterable):
+    p = 1.0
+    for x in iterable:
+        p *= x
+    return p
+
 
 # ### Matrix and vector products ###
+
 
 @normalizer
 def matrix_power(a: ArrayLike, n):
@@ -36,10 +42,11 @@ def matrix_power(a: ArrayLike, n):
 
 @normalizer
 def multi_dot(inputs, *, out=None):
-    return torch.linalg.multi_dot(inputs)    
+    return torch.linalg.multi_dot(inputs)
 
 
 # ### Solving equations and inverting matrices ###
+
 
 @normalizer
 def solve(a: ArrayLike, b: ArrayLike):
@@ -51,7 +58,7 @@ def solve(a: ArrayLike, b: ArrayLike):
 def lstsq(a: ArrayLike, b: ArrayLike, rcond=None):
     a, b = _atleast_float_2(a, b)
     # NumPy is using gelsd: https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/umath_linalg.cpp#L3991
-    return torch.linalg.lstsq(a, b, rcond=rcond, driver='gelsd')
+    return torch.linalg.lstsq(a, b, rcond=rcond, driver="gelsd")
 
 
 @normalizer
@@ -94,22 +101,46 @@ def slogdet(a: ArrayLike):
 
 
 @normalizer
-def cond(a: ArrayLike, p):
-    a = _atleast_float_1(a)
-    return torch.linalg.cond(a, p=p)
+def cond(x: ArrayLike, p=None):
+    x = _atleast_float_1(x)
+
+    # check if empty
+    # cf: https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/linalg.py#L1744
+    if x.numel() == 0 and _prod(x.shape[-2:]) == 0:
+        raise LinAlgError("cond is not defined on empty arrays")
+
+    result = torch.linalg.cond(x, p=p)
+
+    # Convert nans to infs unless the original array had nan entries
+    # XXX: NumPy does this: https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/linalg.py#L1744
+    # Do we want it? .any() synchronizes
+    """
+    nan_mask = torch.isnan(result)
+    if nan_mask.any():
+        nan_mask &= ~torch.isnan(x).any(axis=(-2, -1))  # XXX: any() w/ tuple axes
+        if result.ndim > 0:
+            result[nan_mask] = torch.inf
+        elif nan_mask:
+            result[()] = torch.inf
+    """
+
+    return result
 
 
 @normalizer
 def matrix_rank(a: ArrayLike, tol=None, hermitian=False):
     a = _atleast_float_1(a)
+
+    if a.ndim < 2:
+        return int(not (a == 0).all())
+
     if tol is None:
         # follow https://github.com/numpy/numpy/blob/v1.24.0/numpy/linalg/linalg.py#L1885
         atol = 0
-        rtol = max(a.shape[-2:]) * tnp.finfo(a.dtype).eps
+        rtol = max(a.shape[-2:]) * torch.finfo(a.dtype).eps
     else:
         atol, rtol = tol, 0
     return torch.linalg.matrix_rank(a, atol=atol, rtol=rtol, hermitian=hermitian)
-
 
 
 @normalizer
@@ -117,12 +148,12 @@ def norm(x: ArrayLike, ord=None, axis=None, keepdims=False):
     x = _atleast_float_1(x)
     result = torch.linalg.norm(x, ord=ord, dim=axis)
     if keepdims:
-        result = _util.apply_keepdims(result, axis, tensor.ndim)
+        result = _util.apply_keepdims(result, axis, x.ndim)
     return result
 
 
-
 # ### Decompositions ###
+
 
 @normalizer
 def cholesky(a: ArrayLike):
@@ -131,10 +162,10 @@ def cholesky(a: ArrayLike):
 
 
 @normalizer
-def qr(a: ArrayLike, mode='reduced'):
+def qr(a: ArrayLike, mode="reduced"):
     a = _atleast_float_1(a)
     result = torch.linalg.qr(a, mode=mode)
-    if mode == 'r':
+    if mode == "r":
         # match NumPy
         result = result.R
     return result
@@ -152,14 +183,21 @@ def svd(a: ArrayLike, full_matrices=True, compute_uv=True, hermitian=False):
 
 # ### Eigenvalues and eigenvectors ###
 
+
 @normalizer
 def eig(a: ArrayLike):
     a = _atleast_float_1(a)
-    return torch.linalg.eig(a)
+    w, vt = torch.linalg.eig(a)
+
+    if not a.is_complex():
+        if w.is_complex() and (w.imag == 0).all():
+            w = w.real
+            vt = vt.real
+    return w, vt
 
 
 @normalizer
-def eigh(a: ArrayLike, UPLO='L'):
+def eigh(a: ArrayLike, UPLO="L"):
     a = _atleast_float_1(a)
     return torch.linalg.eigh(a, UPLO=UPLO)
 
@@ -167,14 +205,14 @@ def eigh(a: ArrayLike, UPLO='L'):
 @normalizer
 def eigvals(a: ArrayLike):
     a = _atleast_float_1(a)
-    return torch.linalg.eigvals(a)
+    result = torch.linalg.eigvals(a)
+    if not a.is_complex():
+        if result.is_complex() and (result.imag == 0).all():
+            result = result.real
+    return result
 
 
 @normalizer
-def eigvalsh(a: ArrayLike, UPLO='L'):
+def eigvalsh(a: ArrayLike, UPLO="L"):
     a = _atleast_float_1(a)
     return torch.linalg.eigvalsh(a, UPLO=UPLO)
-
-
-
-

--- a/torch_np/tests/numpy_tests/linalg/test_linalg.py
+++ b/torch_np/tests/numpy_tests/linalg/test_linalg.py
@@ -705,7 +705,6 @@ class TestCond(CondCases):
         assert_almost_equal(linalg.cond(A, -1), 0.5)
         assert_almost_equal(linalg.cond(A, 'fro'), np.sqrt(265 / 12))
 
-    @pytest.mark.xfail(reason="nan -> inf, as numpy does")
     def test_singular(self):
         # Singular matrices have infinite condition number for
         # positive norms, and negative norms shouldn't raise
@@ -747,7 +746,6 @@ class TestCond(CondCases):
                 assert_(not np.isnan(c[0]))
                 assert_(not np.isnan(c[2]))
 
-    @pytest.mark.xfail(reason="nan -> inf, as numpy does")
     def test_stacked_singular(self):
         # Check behavior when only some of the stacked matrices are
         # singular

--- a/torch_np/tests/numpy_tests/linalg/test_linalg.py
+++ b/torch_np/tests/numpy_tests/linalg/test_linalg.py
@@ -320,10 +320,12 @@ class LinalgNonsquareTestCase(LinalgTestCase):
 
 class HermitianTestCase(LinalgTestCase):
 
+    @pytest.mark.xfail(reason="zero-sized arrays")
     def test_herm_cases(self):
         self.check_cases(require={'hermitian'},
                          exclude={'generalized', 'size-0'})
 
+    @pytest.mark.xfail(reason="zero-sized arrays")
     def test_empty_herm_cases(self):
         self.check_cases(require={'hermitian', 'size-0'},
                          exclude={'generalized'})
@@ -403,13 +405,13 @@ class SolveCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
         assert_(consistent_subclass(x, b))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestSolve(SolveCases):
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
         assert_equal(linalg.solve(x, x).dtype, dtype)
 
+    @pytest.mark.xfail(reason="zero-sized arrays")
     def test_0_size(self):
         class ArraySubclass(np.ndarray):
             pass
@@ -443,6 +445,7 @@ class TestSolve(SolveCases):
         assert_raises(ValueError, linalg.solve, a[0:0], b[0:0])
         assert_raises(ValueError, linalg.solve, a[:, 0:0, 0:0], b)
 
+    @pytest.mark.xfail(reason="zero-sized arrays")
     def test_0_size_k(self):
         # test zero multiple equation (K=0) case.
         class ArraySubclass(np.ndarray):
@@ -471,13 +474,13 @@ class InvCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
         assert_(consistent_subclass(a_inv, a))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestInv(InvCases):
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
         assert_equal(linalg.inv(x).dtype, dtype)
 
+    @pytest.mark.xfail(reason="zero-sized arrays")
     def test_0_size(self):
         # Check that all kinds of 0-sized arrays work
         class ArraySubclass(np.ndarray):
@@ -503,7 +506,7 @@ class EigvalsCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
         assert_almost_equal(ev, evalues)
 
 
-@pytest.mark.xfail(reason='TODO')
+
 class TestEigvals(EigvalsCases):
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
@@ -512,6 +515,7 @@ class TestEigvals(EigvalsCases):
         x = np.array([[1, 0.5], [-1, 1]], dtype=dtype)
         assert_equal(linalg.eigvals(x).dtype, get_complex_dtype(dtype))
 
+    @pytest.mark.xfail(reason="zero-sized arrays")
     def test_0_size(self):
         # Check that all kinds of 0-sized arrays work
         class ArraySubclass(np.ndarray):
@@ -541,7 +545,6 @@ class EigCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
         assert_(consistent_subclass(evectors, a))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestEig(EigCases):
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
@@ -555,6 +558,7 @@ class TestEig(EigCases):
         assert_equal(w.dtype, get_complex_dtype(dtype))
         assert_equal(v.dtype, get_complex_dtype(dtype))
 
+    @pytest.mark.xfail(reason="zero-sized arrays")
     def test_0_size(self):
         # Check that all kinds of 0-sized arrays work
         class ArraySubclass(np.ndarray):
@@ -603,7 +607,6 @@ class SVDCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
         assert_(consistent_subclass(vt, a))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestSVD(SVDCases, SVDBaseTests):
     def test_empty_identity(self):
         """ Empty input should put an identity matrix in u or vh """
@@ -639,7 +642,6 @@ class SVDHermitianCases(HermitianTestCase, HermitianGeneralizedTestCase):
         assert_(consistent_subclass(vt, a))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestSVDHermitian(SVDHermitianCases, SVDBaseTests):
     hermitian = True
 
@@ -690,7 +692,6 @@ class CondCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
             single_decimal=5, double_decimal=11)
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestCond(CondCases):
     def test_basic_nonsvd(self):
         # Smoketest the non-svd norms
@@ -701,6 +702,7 @@ class TestCond(CondCases):
         assert_almost_equal(linalg.cond(A, -1), 0.5)
         assert_almost_equal(linalg.cond(A, 'fro'), np.sqrt(265 / 12))
 
+    @pytest.mark.xfail(reason="nan -> inf, as numpy does")
     def test_singular(self):
         # Singular matrices have infinite condition number for
         # positive norms, and negative norms shouldn't raise
@@ -742,6 +744,7 @@ class TestCond(CondCases):
                 assert_(not np.isnan(c[0]))
                 assert_(not np.isnan(c[2]))
 
+    @pytest.mark.xfail(reason="nan -> inf, as numpy does")
     def test_stacked_singular(self):
         # Check behavior when only some of the stacked matrices are
         # singular
@@ -771,7 +774,6 @@ class PinvCases(LinalgSquareTestCase,
         assert_(consistent_subclass(a_ginv, a))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestPinv(PinvCases):
     pass
 
@@ -786,7 +788,6 @@ class PinvHermitianCases(HermitianTestCase, HermitianGeneralizedTestCase):
         assert_(consistent_subclass(a_ginv, a))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestPinvHermitian(PinvHermitianCases):
     pass
 
@@ -811,20 +812,20 @@ class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
         assert_equal(ld[~m], -inf)
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestDet(DetCases):
     def test_zero(self):
+        # NB: comment out tests of type(det) == double : we return zero-dim arrays
         assert_equal(linalg.det([[0.0]]), 0.0)
-        assert_equal(type(linalg.det([[0.0]])), double)
+    #    assert_equal(type(linalg.det([[0.0]])), double)
         assert_equal(linalg.det([[0.0j]]), 0.0)
-        assert_equal(type(linalg.det([[0.0j]])), cdouble)
+    #    assert_equal(type(linalg.det([[0.0j]])), cdouble)
 
         assert_equal(linalg.slogdet([[0.0]]), (0.0, -inf))
-        assert_equal(type(linalg.slogdet([[0.0]])[0]), double)
-        assert_equal(type(linalg.slogdet([[0.0]])[1]), double)
+    #    assert_equal(type(linalg.slogdet([[0.0]])[0]), double)
+    #    assert_equal(type(linalg.slogdet([[0.0]])[1]), double)
         assert_equal(linalg.slogdet([[0.0j]]), (0.0j, -inf))
-        assert_equal(type(linalg.slogdet([[0.0j]])[0]), cdouble)
-        assert_equal(type(linalg.slogdet([[0.0j]])[1]), double)
+    #    assert_equal(type(linalg.slogdet([[0.0j]])[0]), cdouble)
+    #    assert_equal(type(linalg.slogdet([[0.0j]])[1]), double)
 
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
@@ -854,6 +855,14 @@ class TestDet(DetCases):
         assert_(res[1].dtype.type is np.float64)
 
 
+    # stub out these two tests inherited from superclasses
+    def test_empty_sq_cases(self):
+        pytest.xfail("multiply.reduce")
+
+    def test_sq_cases(self):
+        pytest.xfail("multiply.reduce")
+
+
 class LstsqCases(LinalgSquareTestCase, LinalgNonsquareTestCase):
 
     def do(self, a, b, tags):
@@ -864,28 +873,29 @@ class LstsqCases(LinalgSquareTestCase, LinalgNonsquareTestCase):
         if m == 0:
             assert_((x == 0).all())
         if m <= n:
-            assert_almost_equal(b, dot(a, x))
+            assert_almost_equal(b, dot(a, x), single_decimal=5)
             assert_equal(rank, m)
         else:
             assert_equal(rank, n)
-        assert_almost_equal(sv, sv.__array_wrap__(s))
+   #     assert_almost_equal(sv, sv.__array_wrap__(s))
         if rank == n and m > n:
             expect_resids = (
                 np.asarray(abs(np.dot(a, x) - b)) ** 2).sum(axis=0)
             expect_resids = np.asarray(expect_resids)
             if np.asarray(b).ndim == 1:
-                expect_resids.shape = (1,)
+                expect_resids = expect_resids.reshape(1,)
                 assert_equal(residuals.shape, expect_resids.shape)
         else:
-            expect_resids = np.array([]).view(type(x))
-        assert_almost_equal(residuals, expect_resids)
+            expect_resids = np.array([])   #.view(type(x))
+        assert_almost_equal(residuals, expect_resids, single_decimal=5)
         assert_(np.issubdtype(residuals.dtype, np.floating))
         assert_(consistent_subclass(x, b))
         assert_(consistent_subclass(residuals, b))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestLstsq(LstsqCases):
+
+    @pytest.mark.xfail(reason="Lstsq: we use the future default =None")
     def test_future_rcond(self):
         a = np.array([[0., 1.,  0.,  1.,  2.,  0.],
                       [0., 2.,  0.,  0.,  1.,  0.],
@@ -910,7 +920,7 @@ class TestLstsq(LstsqCases):
         (0, 4, 2),
         (4, 0, 1),
         (4, 0, 2),
-        (4, 2, 0),
+    #    (4, 2, 0),    # Intel MKL ERROR: Parameter 4 was incorrect on entry to DLALSD.
         (0, 0, 0)
     ])
     def test_empty_a_b(self, m, n, n_rhs):
@@ -934,7 +944,7 @@ class TestLstsq(LstsqCases):
         y = np.array([-1, 0.2, 0.9, 2.1, 3.3])
         A = np.vstack([x, np.ones(len(x))]).T
 #        with assert_raises_regex(LinAlgError, "Incompatible dimensions"):
-        with assert_raises(LinAlgError):
+        with assert_raises((RuntimeError, LinAlgError)):
             linalg.lstsq(A, y, rcond=None)
 
 
@@ -1028,7 +1038,6 @@ class TestMatrixPower:
         assert_raises(LinAlgError, matrix_power, mat, -1)
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestEigvalshCases(HermitianTestCase, HermitianGeneralizedTestCase):
 
     def do(self, a, b, tags):
@@ -1043,7 +1052,6 @@ class TestEigvalshCases(HermitianTestCase, HermitianGeneralizedTestCase):
         assert_allclose(ev2, evalues, rtol=get_rtol(ev.dtype))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestEigvalsh:
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
@@ -1053,9 +1061,9 @@ class TestEigvalsh:
 
     def test_invalid(self):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=np.float32)
-        assert_raises(ValueError, np.linalg.eigvalsh, x, UPLO="lrong")
-        assert_raises(ValueError, np.linalg.eigvalsh, x, "lower")
-        assert_raises(ValueError, np.linalg.eigvalsh, x, "upper")
+        assert_raises((RuntimeError, ValueError), np.linalg.eigvalsh, x, UPLO="lrong")
+        assert_raises((RuntimeError, ValueError), np.linalg.eigvalsh, x, "lower")
+        assert_raises((RuntimeError, ValueError), np.linalg.eigvalsh, x, "upper")
 
     def test_UPLO(self):
         Klo = np.array([[0, 0], [1, 0]], dtype=np.double)
@@ -1081,16 +1089,16 @@ class TestEigvalsh:
 
     def test_0_size(self):
         # Check that all kinds of 0-sized arrays work
-        class ArraySubclass(np.ndarray):
-            pass
-        a = np.zeros((0, 1, 1), dtype=np.int_).view(ArraySubclass)
+   #     class ArraySubclass(np.ndarray):
+   #         pass
+        a = np.zeros((0, 1, 1), dtype=np.int_)   #.view(ArraySubclass)
         res = linalg.eigvalsh(a)
         assert_(res.dtype.type is np.float64)
         assert_equal((0, 1), res.shape)
         # This is just for documentation, it might make sense to change:
         assert_(isinstance(res, np.ndarray))
 
-        a = np.zeros((0, 0), dtype=np.complex64).view(ArraySubclass)
+        a = np.zeros((0, 0), dtype=np.complex64)   #.view(ArraySubclass)
         res = linalg.eigvalsh(a)
         assert_(res.dtype.type is np.float32)
         assert_equal((0,), res.shape)
@@ -1098,7 +1106,6 @@ class TestEigvalsh:
         assert_(isinstance(res, np.ndarray))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestEighCases(HermitianTestCase, HermitianGeneralizedTestCase):
 
     def do(self, a, b, tags):
@@ -1121,7 +1128,6 @@ class TestEighCases(HermitianTestCase, HermitianGeneralizedTestCase):
                         rtol=get_rtol(ev.dtype), err_msg=repr(a))
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestEigh:
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
@@ -1132,9 +1138,9 @@ class TestEigh:
 
     def test_invalid(self):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=np.float32)
-        assert_raises(ValueError, np.linalg.eigh, x, UPLO="lrong")
-        assert_raises(ValueError, np.linalg.eigh, x, "lower")
-        assert_raises(ValueError, np.linalg.eigh, x, "upper")
+        assert_raises((RuntimeError, ValueError), np.linalg.eigh, x, UPLO="lrong")
+        assert_raises((RuntimeError, ValueError), np.linalg.eigh, x, "lower")
+        assert_raises((RuntimeError, ValueError), np.linalg.eigh, x, "upper")
 
     def test_UPLO(self):
         Klo = np.array([[0, 0], [1, 0]], dtype=np.double)
@@ -1160,9 +1166,9 @@ class TestEigh:
 
     def test_0_size(self):
         # Check that all kinds of 0-sized arrays work
-        class ArraySubclass(np.ndarray):
-            pass
-        a = np.zeros((0, 1, 1), dtype=np.int_).view(ArraySubclass)
+#        class ArraySubclass(np.ndarray):
+#            pass
+        a = np.zeros((0, 1, 1), dtype=np.int_) #.view(ArraySubclass)
         res, res_v = linalg.eigh(a)
         assert_(res_v.dtype.type is np.float64)
         assert_(res.dtype.type is np.float64)
@@ -1171,7 +1177,7 @@ class TestEigh:
         # This is just for documentation, it might make sense to change:
         assert_(isinstance(a, np.ndarray))
 
-        a = np.zeros((0, 0), dtype=np.complex64).view(ArraySubclass)
+        a = np.zeros((0, 0), dtype=np.complex64) #.view(ArraySubclass)
         res, res_v = linalg.eigh(a)
         assert_(res_v.dtype.type is np.complex64)
         assert_(res.dtype.type is np.float32)
@@ -1211,6 +1217,9 @@ class _TestNormGeneral(_TestNormBase):
 
         for each_type in all_types:
             at = a.astype(each_type)
+
+            if each_type == np.dtype('float16'):
+                pytest.xfail('float16**float64 => float64 (?)')
 
             an = norm(at, -np.inf)
             self.check_dtype(at, an)
@@ -1277,7 +1286,7 @@ class _TestNormGeneral(_TestNormBase):
         # Compare the use of `axis` with computing the norm of each row
         # or column separately.
         A = array([[1, 2, 3], [4, 5, 6]], dtype=self.dt)
-        for order in [None, -1, 0, 1, 2, 3, np.Inf, -np.Inf]:
+        for order in [None, -1, 0, 1, 2, 3, np.inf, -np.inf]:
             expected0 = [norm(A[:, k], ord=order) for k in range(A.shape[1])]
             assert_almost_equal(norm(A, ord=order, axis=0), expected0)
             expected1 = [norm(A[k, :], ord=order) for k in range(A.shape[0])]
@@ -1286,7 +1295,7 @@ class _TestNormGeneral(_TestNormBase):
         # Matrix norms.
         B = np.arange(1, 25, dtype=self.dt).reshape(2, 3, 4)
         nd = B.ndim
-        for order in [None, -2, 2, -1, 1, np.Inf, -np.Inf, 'fro']:
+        for order in [None, -2, 2, -1, 1, np.inf, -np.inf, 'fro']:
             for axis in itertools.combinations(range(-nd, nd), 2):
                 row_axis, col_axis = axis
                 if row_axis < 0:
@@ -1294,7 +1303,7 @@ class _TestNormGeneral(_TestNormBase):
                 if col_axis < 0:
                     col_axis += nd
                 if row_axis == col_axis:
-                    assert_raises(ValueError, norm, B, ord=order, axis=axis)
+                    assert_raises((RuntimeError, ValueError), norm, B, ord=order, axis=axis)
                 else:
                     n = norm(B, ord=order, axis=axis)
 
@@ -1325,7 +1334,7 @@ class _TestNormGeneral(_TestNormBase):
                 shape_err.format(found.shape, expected_shape, None, None))
 
         # Vector norms.
-        for order in [None, -1, 0, 1, 2, 3, np.Inf, -np.Inf]:
+        for order in [None, -1, 0, 1, 2, 3, np.inf, -np.inf]:
             for k in range(A.ndim):
                 expected = norm(A, ord=order, axis=k)
                 found = norm(A, ord=order, axis=k, keepdims=True)
@@ -1338,7 +1347,7 @@ class _TestNormGeneral(_TestNormBase):
                         shape_err.format(found.shape, expected_shape, order, k))
 
         # Matrix norms.
-        for order in [None, -2, 2, -1, 1, np.Inf, -np.Inf, 'fro', 'nuc']:
+        for order in [None, -2, 2, -1, 1, np.inf, -np.inf, 'fro', 'nuc']:
             for k in itertools.permutations(range(A.ndim), 2):
                 expected = norm(A, ord=order, axis=k)
                 found = norm(A, ord=order, axis=k, keepdims=True)
@@ -1355,13 +1364,12 @@ class _TestNormGeneral(_TestNormBase):
 class _TestNorm2D(_TestNormBase):
     # Define the part for 2d arrays separately, so we can subclass this
     # and run the tests using np.matrix in matrixlib.tests.test_matrix_linalg.
-    array = np.array
 
     def test_matrix_empty(self):
-        assert_equal(norm(self.array([[]], dtype=self.dt)), 0.0)
+        assert_equal(norm(np.array([[]], dtype=self.dt)), 0.0)
 
     def test_matrix_return_type(self):
-        a = self.array([[1, 0, 1], [0, 1, 1]])
+        a = np.array([[1, 0, 1], [0, 1, 1]])
 
         exact_types = np.typecodes['AllInteger']
 
@@ -1412,7 +1420,7 @@ class _TestNorm2D(_TestNormBase):
             np.testing.assert_almost_equal(an, 2.7320508075688772, decimal=6)
 
     def test_matrix_2x2(self):
-        A = self.array([[1, 3], [5, 7]], dtype=self.dt)
+        A = np.array([[1, 3], [5, 7]], dtype=self.dt)
         assert_almost_equal(norm(A), 84 ** 0.5)
         assert_almost_equal(norm(A, 'fro'), 84 ** 0.5)
         assert_almost_equal(norm(A, 'nuc'), 10.0)
@@ -1423,9 +1431,9 @@ class _TestNorm2D(_TestNormBase):
         assert_almost_equal(norm(A, 2), 9.1231056256176615)
         assert_almost_equal(norm(A, -2), 0.87689437438234041)
 
-        assert_raises(ValueError, norm, A, 'nofro')
-        assert_raises(ValueError, norm, A, -3)
-        assert_raises(ValueError, norm, A, 0)
+        assert_raises((RuntimeError, ValueError), norm, A, 'nofro')
+        assert_raises((RuntimeError, ValueError), norm, A, -3)
+        assert_raises((RuntimeError, ValueError), norm, A, 0)
 
     def test_matrix_3x3(self):
         # This test has been added because the 2x2 example
@@ -1433,7 +1441,7 @@ class _TestNorm2D(_TestNormBase):
         # The 1/10 scaling factor accommodates the absolute tolerance
         # used in assert_almost_equal.
         A = (1 / 10) * \
-            self.array([[1, 2, 3], [6, 0, 5], [3, 2, 1]], dtype=self.dt)
+            np.array([[1, 2, 3], [6, 0, 5], [3, 2, 1]], dtype=self.dt)
         assert_almost_equal(norm(A), (1 / 10) * 89 ** 0.5)
         assert_almost_equal(norm(A, 'fro'), (1 / 10) * 89 ** 0.5)
         assert_almost_equal(norm(A, 'nuc'), 1.3366836911774836)
@@ -1447,61 +1455,42 @@ class _TestNorm2D(_TestNormBase):
     def test_bad_args(self):
         # Check that bad arguments raise the appropriate exceptions.
 
-        A = self.array([[1, 2, 3], [4, 5, 6]], dtype=self.dt)
+        A = np.array([[1, 2, 3], [4, 5, 6]], dtype=self.dt)
         B = np.arange(1, 25, dtype=self.dt).reshape(2, 3, 4)
 
         # Using `axis=<integer>` or passing in a 1-D array implies vector
         # norms are being computed, so also using `ord='fro'`
         # or `ord='nuc'` or any other string raises a ValueError.
-        assert_raises(ValueError, norm, A, 'fro', 0)
-        assert_raises(ValueError, norm, A, 'nuc', 0)
-        assert_raises(ValueError, norm, [3, 4], 'fro', None)
-        assert_raises(ValueError, norm, [3, 4], 'nuc', None)
-        assert_raises(ValueError, norm, [3, 4], 'test', None)
+        assert_raises((RuntimeError, ValueError), norm, A, 'fro', 0)
+        assert_raises((RuntimeError, ValueError), norm, A, 'nuc', 0)
+        assert_raises((RuntimeError, ValueError), norm, [3, 4], 'fro', None)
+        assert_raises((RuntimeError, ValueError), norm, [3, 4], 'nuc', None)
+        assert_raises((RuntimeError, ValueError), norm, [3, 4], 'test', None)
 
         # Similarly, norm should raise an exception when ord is any finite
         # number other than 1, 2, -1 or -2 when computing matrix norms.
         for order in [0, 3]:
-            assert_raises(ValueError, norm, A, order, None)
-            assert_raises(ValueError, norm, A, order, (0, 1))
-            assert_raises(ValueError, norm, B, order, (1, 2))
+            assert_raises((RuntimeError, ValueError), norm, A, order, None)
+            assert_raises((RuntimeError, ValueError), norm, A, order, (0, 1))
+            assert_raises((RuntimeError, ValueError), norm, B, order, (1, 2))
 
         # Invalid axis
-        assert_raises(np.AxisError, norm, B, None, 3)
-        assert_raises(np.AxisError, norm, B, None, (2, 3))
-        assert_raises(ValueError, norm, B, None, (0, 1, 2))
+        assert_raises((IndexError, np.AxisError), norm, B, None, 3)
+        assert_raises((IndexError, np.AxisError), norm, B, None, (2, 3))
+        assert_raises((RuntimeError, ValueError), norm, B, None, (0, 1, 2))
 
 
 class _TestNorm(_TestNorm2D, _TestNormGeneral):
     pass
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestNorm_NonSystematic:
-
-    def test_longdouble_norm(self):
-        # Non-regression test: p-norm of longdouble would previously raise
-        # UnboundLocalError.
-        x = np.arange(10, dtype=np.longdouble)
-        old_assert_almost_equal(norm(x, ord=3), 12.65, decimal=2)
 
     def test_intmin(self):
         # Non-regression test: p-norm of signed integer would previously do
         # float cast and abs in the wrong order.
         x = np.array([-2 ** 31], dtype=np.int32)
         old_assert_almost_equal(norm(x, ord=3), 2 ** 31, decimal=5)
-
-    def test_complex_high_ord(self):
-        # gh-4156
-        d = np.empty((2,), dtype=np.clongdouble)
-        d[0] = 6 + 7j
-        d[1] = -6 + 7j
-        res = 11.615898132184
-        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=10)
-        d = d.astype(np.complex128)
-        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=9)
-        d = d.astype(np.complex64)
-        old_assert_almost_equal(np.linalg.norm(d, ord=3), res, decimal=5)
 
 
 # Separate definitions so we can use them for matrix tests.
@@ -1520,22 +1509,18 @@ class _TestNormInt64Base(_TestNormBase):
     dec = 12
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestNormDouble(_TestNorm, _TestNormDoubleBase):
     pass
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestNormSingle(_TestNorm, _TestNormSingleBase):
     pass
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestNormInt64(_TestNorm, _TestNormInt64Base):
     pass
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestMatrixRank:
 
     def test_matrix_rank(self):
@@ -1572,13 +1557,13 @@ class TestMatrixRank:
         assert_equal(3, matrix_rank(I, hermitian=True, tol=1.01e-8))
 
 
-@pytest.mark.xfail(reason='TODO')
 def test_reduced_rank():
     # Test matrices with reduced rank
-    rng = np.random.RandomState(20120714)
+  #  rng = np.random.RandomState(20120714)
+    np.random.seed(20120714)
     for i in range(100):
         # Make a rank deficient matrix
-        X = rng.normal(size=(40, 10))
+        X = np.random.normal(size=(40, 10))
         X[:, 0] = X[:, 1] + X[:, 2]
         # Assert that matrix_rank detected deficiency
         assert_equal(matrix_rank(X), 9)
@@ -1586,10 +1571,7 @@ def test_reduced_rank():
         assert_equal(matrix_rank(X), 8)
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestQR:
-    # Define the array class here, so run this on matrices elsewhere.
-    array = np.array
 
     def check_qr(self, a):
         # This test expects the argument `a` to be an ndarray or
@@ -1607,7 +1589,7 @@ class TestQR:
         assert_(isinstance(r, a_type))
         assert_(q.shape == (m, m))
         assert_(r.shape == (m, n))
-        assert_almost_equal(dot(q, r), a)
+        assert_almost_equal(dot(q, r), a, single_decimal=5)
         assert_almost_equal(dot(q.T.conj(), q), np.eye(m))
         assert_almost_equal(np.triu(r), r)
 
@@ -1619,7 +1601,7 @@ class TestQR:
         assert_(isinstance(r1, a_type))
         assert_(q1.shape == (m, k))
         assert_(r1.shape == (k, n))
-        assert_almost_equal(dot(q1, r1), a)
+        assert_almost_equal(dot(q1, r1), a, single_decimal=5)
         assert_almost_equal(dot(q1.T.conj(), q1), np.eye(k))
         assert_almost_equal(np.triu(r1), r1)
 
@@ -1630,6 +1612,7 @@ class TestQR:
         assert_almost_equal(r2, r1)
 
 
+    @pytest.mark.xfail(reason="torch does not allow qr(..., mode='raw'")
     @pytest.mark.parametrize(["m", "n"], [
         (3, 0),
         (0, 3),
@@ -1647,6 +1630,7 @@ class TestQR:
         assert_equal(h.shape, (n, m))
         assert_equal(tau.shape, (k,))
 
+    @pytest.mark.xfail(reason="torch does not allow qr(..., mode='raw'")
     def test_mode_raw(self):
         # The factorization is not unique and varies between libraries,
         # so it is not possible to check against known values. Functional
@@ -1654,7 +1638,7 @@ class TestQR:
         # of the functions in lapack_lite. Consequently, this test is
         # very limited in scope. Note that the results are in FORTRAN
         # order, hence the h arrays are transposed.
-        a = self.array([[1, 2], [3, 4], [5, 6]], dtype=np.double)
+        a = np.array([[1, 2], [3, 4], [5, 6]], dtype=np.double)
 
         # Test double
         h, tau = linalg.qr(a, mode='raw')
@@ -1670,8 +1654,8 @@ class TestQR:
         assert_(tau.shape == (2,))
 
     def test_mode_all_but_economic(self):
-        a = self.array([[1, 2], [3, 4]])
-        b = self.array([[1, 2], [3, 4], [5, 6]])
+        a = np.array([[1, 2], [3, 4]])
+        b = np.array([[1, 2], [3, 4], [5, 6]])
         for dt in "fd":
             m1 = a.astype(dt)
             m2 = b.astype(dt)
@@ -1747,7 +1731,6 @@ class TestQR:
         self.check_qr_stacked(A + 1.j*B)
 
 
-@pytest.mark.xfail(reason='TODO')
 class TestCholesky:
     # TODO: are there no other tests for cholesky?
 
@@ -1773,21 +1756,20 @@ class TestCholesky:
         c = np.linalg.cholesky(a)
 
         b = np.matmul(c, c.transpose(t).conj())
-        with np._no_nep50_warning():
-            atol = 500 * a.shape[0] * np.finfo(dtype).eps
+        atol = 500 * a.shape[0] * np.finfo(dtype).eps
         assert_allclose(b, a, atol=atol, err_msg=f'{shape} {dtype}\n{a}\n{c}')
 
     def test_0_size(self):
-        class ArraySubclass(np.ndarray):
-            pass
-        a = np.zeros((0, 1, 1), dtype=np.int_).view(ArraySubclass)
+   #     class ArraySubclass(np.ndarray):
+   #         pass
+        a = np.zeros((0, 1, 1), dtype=np.int_)  #.view(ArraySubclass)
         res = linalg.cholesky(a)
         assert_equal(a.shape, res.shape)
         assert_(res.dtype.type is np.float64)
         # for documentation purpose:
         assert_(isinstance(res, np.ndarray))
 
-        a = np.zeros((1, 0, 0), dtype=np.complex64).view(ArraySubclass)
+        a = np.zeros((1, 0, 0), dtype=np.complex64) #.view(ArraySubclass)
         res = linalg.cholesky(a)
         assert_equal(a.shape, res.shape)
         assert_(res.dtype.type is np.complex64)


### PR DESCRIPTION
Implement linalg mappings. This PR does nearly all of linalg (sans einsum). So far this is not completely consistent on
- the type of exceptions: torch raises RuntimeErrors, sometimes `torch._C._LinAlgError`s; we mostly pass the former through and convert the latter
- zero-size arrays. NumPy handles them, but torch doesn't seem to. So just xfail the corresponding tests. 