### PR TITLE
BUG: fix nout=2 ufuncs

### DIFF
--- a/torch_np/_normalizations.py
+++ b/torch_np/_normalizations.py
@@ -80,7 +80,7 @@ def normalize_ndarray(arg, name=None):
     from ._ndarray import ndarray
 
     if not isinstance(arg, ndarray):
-        raise TypeError("'out' must be an array")
+        raise TypeError(f"'{name}' must be an array")
     return arg.tensor
 
 
@@ -135,8 +135,9 @@ def maybe_copy_to(out, result, promote_scalar_result=False):
         out.tensor.copy_(result)
         return out
     elif isinstance(result, (tuple, list)):
-        # FIXME: this is broken (there is no copy_to)
-        return type(result)(map(copy_to, zip(result, out)))
+        return type(result)(
+            maybe_copy_to(o, r, promote_scalar_result) for o, r in zip(out, result)
+        )
     else:
         assert False  # We should never hit this path
 

--- a/torch_np/_ufuncs.py
+++ b/torch_np/_ufuncs.py
@@ -128,13 +128,14 @@ def divmod(
     num_outs = sum(x is not None for x in [out1, out2])
     if num_outs == 1:
         raise ValueError("both out1 and out2 need to be provided")
+    elif num_outs == 2:
+        o1, o2 = out
+        if o1 is not None or o2 is not None:
+            raise TypeError(
+                "cannot specify 'out' as both a positional and keyword argument"
+            )
     else:
         out1, out2 = out
-        if num_outs == 2:
-            if out1 is not None or out2 is not None:
-                raise TypeError(
-                    "cannot specify 'out' as both a positional and keyword argument"
-                )
 
     tensors = _ufunc_preprocess(
         (x1, x2), True, casting, order, dtype, subok, signature, extobj

--- a/torch_np/tests/test_basic.py
+++ b/torch_np/tests/test_basic.py
@@ -475,6 +475,18 @@ class TestDivmod:
         assert quot is out[0]
         assert rem is out[1]
 
+    @pytest.mark.xfail(reason="out1, out2 not implemented")
+    def test_divmod_pos_only(self):
+        x1 = [4, 5, 6]
+        x2 = [2, 1, 2]
+
+        out1, out2 = w.empty_like(x1), w.empty_like(x1)
+
+        quot, rem = w.divmod(x1, x2, out1, out2)
+
+        assert quot is out1
+        assert rem is out2
+
     def test_divmod_no_out(self):
         # check that the out= machinery handles no out at all
         x1 = w.array([4, 5, 6])

--- a/torch_np/tests/test_basic.py
+++ b/torch_np/tests/test_basic.py
@@ -7,6 +7,7 @@ from pytest import raises as assert_raises
 
 import torch_np as w
 import torch_np._ufuncs as _ufuncs
+from torch_np.testing import assert_equal
 
 # These function receive one array_like arg and return one array_like result
 one_arg_funcs = [
@@ -445,3 +446,45 @@ class TestCopyTo:
         # force the type cast
         w.copyto(dst, src, casting="unsafe")
         assert (dst == src).all()
+
+
+class TestDivmod:
+    def test_divmod_out(self):
+        x1 = w.arange(8, 15)
+        x2 = w.arange(4, 11)
+
+        out = (w.empty_like(x1), w.empty_like(x1))
+
+        quot, rem = w.divmod(x1, x2, out=out)
+
+        assert_equal(quot, x1 // x2)
+        assert_equal(rem, x1 % x2)
+
+        out1, out2 = out
+        assert quot is out[0]
+        assert rem is out[1]
+
+    def test_divmod_out_list(self):
+        x1 = [4, 5, 6]
+        x2 = [2, 1, 2]
+
+        out = (w.empty_like(x1), w.empty_like(x1))
+
+        quot, rem = w.divmod(x1, x2, out=out)
+
+        assert quot is out[0]
+        assert rem is out[1]
+
+    def test_divmod_no_out(self):
+        # check that the out= machinery handles no out at all
+        x1 = w.array([4, 5, 6])
+        x2 = w.array([2, 1, 2])
+        quot, rem = w.divmod(x1, x2)
+
+        assert_equal(quot, x1 // x2)
+        assert_equal(rem, x1 % x2)
+
+    def test_divmod_out_both_pos_and_kw(self):
+        o = w.empty(1)
+        with assert_raises(TypeError):
+            w.divmod(1, 2, o, o, out=(o, o))


### PR DESCRIPTION
A minimal fix for a bug in handling of `out=(ndarray, ndarray)`. 