### PR TITLE
MAINT: handle not implemented arguments centrally, via a dedicated annotation

### DIFF
--- a/torch_np/_detail/_reductions.py
+++ b/torch_np/_detail/_reductions.py
@@ -134,9 +134,6 @@ def argmin(tensor, axis=None):
 @emulate_keepdims
 @deco_axis_expand
 def any(tensor, axis=None, *, where=NoValue):
-    if where is not NoValue:
-        raise NotImplementedError
-
     axis = _util.allow_only_single_axis(axis)
 
     if axis is None:
@@ -149,9 +146,6 @@ def any(tensor, axis=None, *, where=NoValue):
 @emulate_keepdims
 @deco_axis_expand
 def all(tensor, axis=None, *, where=NoValue):
-    if where is not NoValue:
-        raise NotImplementedError
-
     axis = _util.allow_only_single_axis(axis)
 
     if axis is None:
@@ -164,36 +158,24 @@ def all(tensor, axis=None, *, where=NoValue):
 @emulate_keepdims
 @deco_axis_expand
 def max(tensor, axis=None, initial=NoValue, where=NoValue):
-    if initial is not NoValue or where is not NoValue:
-        raise NotImplementedError
-
-    result = tensor.amax(axis)
-    return result
+    return tensor.amax(axis)
 
 
 @emulate_keepdims
 @deco_axis_expand
 def min(tensor, axis=None, initial=NoValue, where=NoValue):
-    if initial is not NoValue or where is not NoValue:
-        raise NotImplementedError
-
-    result = tensor.amin(axis)
-    return result
+    return tensor.amin(axis)
 
 
 @emulate_keepdims
 @deco_axis_expand
 def ptp(tensor, axis=None):
-    result = tensor.amax(axis) - tensor.amin(axis)
-    return result
+    return tensor.amax(axis) - tensor.amin(axis)
 
 
 @emulate_keepdims
 @deco_axis_expand
 def sum(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
-    if initial is not NoValue or where is not NoValue:
-        raise NotImplementedError
-
     assert dtype is None or isinstance(dtype, torch.dtype)
 
     if dtype == torch.bool:
@@ -210,9 +192,6 @@ def sum(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
 @emulate_keepdims
 @deco_axis_expand
 def prod(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
-    if initial is not NoValue or where is not NoValue:
-        raise NotImplementedError
-
     axis = _util.allow_only_single_axis(axis)
 
     if dtype == torch.bool:
@@ -229,9 +208,6 @@ def prod(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
 @emulate_keepdims
 @deco_axis_expand
 def mean(tensor, axis=None, dtype=None, *, where=NoValue):
-    if where is not NoValue:
-        raise NotImplementedError
-
     dtype = _atleast_float(dtype, tensor.dtype)
 
     is_half = dtype == torch.float16
@@ -253,9 +229,6 @@ def mean(tensor, axis=None, dtype=None, *, where=NoValue):
 @emulate_keepdims
 @deco_axis_expand
 def std(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
-    if where is not NoValue:
-        raise NotImplementedError
-
     dtype = _atleast_float(dtype, tensor.dtype)
     tensor = _util.cast_if_needed(tensor, dtype)
     result = tensor.std(dim=axis, correction=ddof)
@@ -266,9 +239,6 @@ def std(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
 @emulate_keepdims
 @deco_axis_expand
 def var(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
-    if where is not NoValue:
-        raise NotImplementedError
-
     dtype = _atleast_float(dtype, tensor.dtype)
     tensor = _util.cast_if_needed(tensor, dtype)
     result = tensor.var(dim=axis, correction=ddof)
@@ -386,9 +356,6 @@ def quantile(
         # https://numpy.org/doc/stable/reference/generated/numpy.percentile.html#numpy-percentile
         # Here we choose to work out-of-place because why not.
         pass
-
-    if interpolation is not None:
-        raise ValueError("'interpolation' argument is deprecated; use 'method' instead")
 
     if not a.dtype.is_floating_point:
         dtype = _dtypes_impl.default_float_dtype

--- a/torch_np/_detail/_reductions.py
+++ b/torch_np/_detail/_reductions.py
@@ -4,16 +4,12 @@ in the 'public' layer.
 Anything here only deals with torch objects, e.g. "dtype" is a torch.dtype instance etc
 """
 
+import functools
 import typing
 
 import torch
 
 from . import _dtypes_impl, _util
-
-NoValue = _util.NoValue
-
-
-import functools
 
 ############# XXX
 ### From _util.axis_expand_func
@@ -51,7 +47,7 @@ def deco_axis_expand(func):
 
 def emulate_keepdims(func):
     @functools.wraps(func)
-    def wrapped(tensor, axis=None, keepdims=NoValue, *args, **kwds):
+    def wrapped(tensor, axis=None, keepdims=None, *args, **kwds):
         result = func(tensor, axis=axis, *args, **kwds)
         if keepdims:
             result = _util.apply_keepdims(result, axis, tensor.ndim)
@@ -133,7 +129,7 @@ def argmin(tensor, axis=None):
 
 @emulate_keepdims
 @deco_axis_expand
-def any(tensor, axis=None, *, where=NoValue):
+def any(tensor, axis=None, *, where=None):
     axis = _util.allow_only_single_axis(axis)
 
     if axis is None:
@@ -145,7 +141,7 @@ def any(tensor, axis=None, *, where=NoValue):
 
 @emulate_keepdims
 @deco_axis_expand
-def all(tensor, axis=None, *, where=NoValue):
+def all(tensor, axis=None, *, where=None):
     axis = _util.allow_only_single_axis(axis)
 
     if axis is None:
@@ -157,13 +153,13 @@ def all(tensor, axis=None, *, where=NoValue):
 
 @emulate_keepdims
 @deco_axis_expand
-def max(tensor, axis=None, initial=NoValue, where=NoValue):
+def max(tensor, axis=None, initial=None, where=None):
     return tensor.amax(axis)
 
 
 @emulate_keepdims
 @deco_axis_expand
-def min(tensor, axis=None, initial=NoValue, where=NoValue):
+def min(tensor, axis=None, initial=None, where=None):
     return tensor.amin(axis)
 
 
@@ -175,7 +171,7 @@ def ptp(tensor, axis=None):
 
 @emulate_keepdims
 @deco_axis_expand
-def sum(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
+def sum(tensor, axis=None, dtype=None, initial=None, where=None):
     assert dtype is None or isinstance(dtype, torch.dtype)
 
     if dtype == torch.bool:
@@ -191,7 +187,7 @@ def sum(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
 
 @emulate_keepdims
 @deco_axis_expand
-def prod(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
+def prod(tensor, axis=None, dtype=None, initial=None, where=None):
     axis = _util.allow_only_single_axis(axis)
 
     if dtype == torch.bool:
@@ -207,7 +203,7 @@ def prod(tensor, axis=None, dtype=None, initial=NoValue, where=NoValue):
 
 @emulate_keepdims
 @deco_axis_expand
-def mean(tensor, axis=None, dtype=None, *, where=NoValue):
+def mean(tensor, axis=None, dtype=None, *, where=None):
     dtype = _atleast_float(dtype, tensor.dtype)
 
     is_half = dtype == torch.float16
@@ -228,7 +224,7 @@ def mean(tensor, axis=None, dtype=None, *, where=NoValue):
 
 @emulate_keepdims
 @deco_axis_expand
-def std(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
+def std(tensor, axis=None, dtype=None, ddof=0, *, where=None):
     dtype = _atleast_float(dtype, tensor.dtype)
     tensor = _util.cast_if_needed(tensor, dtype)
     result = tensor.std(dim=axis, correction=ddof)
@@ -238,7 +234,7 @@ def std(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
 
 @emulate_keepdims
 @deco_axis_expand
-def var(tensor, axis=None, dtype=None, ddof=0, *, where=NoValue):
+def var(tensor, axis=None, dtype=None, ddof=0, *, where=None):
     dtype = _atleast_float(dtype, tensor.dtype)
     tensor = _util.cast_if_needed(tensor, dtype)
     result = tensor.var(dim=axis, correction=ddof)

--- a/torch_np/_detail/_util.py
+++ b/torch_np/_detail/_util.py
@@ -7,7 +7,6 @@ import torch
 
 from . import _dtypes_impl
 
-NoValue = None
 
 # https://github.com/numpy/numpy/blob/v1.23.0/numpy/distutils/misc_util.py#L497-L504
 def is_sequence(seq):

--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -28,9 +28,6 @@ from ._normalizations import (
     normalize_array_like,
 )
 
-NoValue = _util.NoValue
-
-
 ###### array creation routines
 
 
@@ -44,7 +41,7 @@ def copyto(
     dst: NDArray,
     src: ArrayLike,
     casting="same_kind",
-    where: NotImplementedType = NoValue,
+    where: NotImplementedType = None,
 ):
     (src,) = _util.typecast_tensors((src,), dst.dtype, casting=casting)
     dst.copy_(src)
@@ -511,8 +508,8 @@ def corrcoef(
     x: ArrayLike,
     y: Optional[ArrayLike] = None,
     rowvar=True,
-    bias=NoValue,
-    ddof=NoValue,
+    bias=None,
+    ddof=None,
     *,
     dtype: DTypeLike = None,
 ):
@@ -762,9 +759,9 @@ def nanmean(
     axis=None,
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
+    keepdims=None,
     *,
-    where: NotImplementedType = NoValue,
+    where: NotImplementedType = None,
 ):
     # XXX: this needs to be rewritten
     if dtype is None:
@@ -1403,9 +1400,9 @@ def sum(
     axis: AxisLike = None,
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
-    initial: NotImplementedType = NoValue,
-    where: NotImplementedType = NoValue,
+    keepdims=None,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
 ):
     result = _impl.sum(
         a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
@@ -1418,9 +1415,9 @@ def prod(
     axis: AxisLike = None,
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
-    initial: NotImplementedType = NoValue,
-    where: NotImplementedType = NoValue,
+    keepdims=None,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
 ):
     result = _impl.prod(
         a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
@@ -1436,11 +1433,11 @@ def mean(
     axis: AxisLike = None,
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
+    keepdims=None,
     *,
-    where: NotImplementedType = NoValue,
+    where: NotImplementedType = None,
 ):
-    result = _impl.mean(a, axis=axis, dtype=dtype, where=NoValue, keepdims=keepdims)
+    result = _impl.mean(a, axis=axis, dtype=dtype, where=None, keepdims=keepdims)
     return result
 
 
@@ -1450,9 +1447,9 @@ def var(
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
     ddof=0,
-    keepdims=NoValue,
+    keepdims=None,
     *,
-    where: NotImplementedType = NoValue,
+    where: NotImplementedType = None,
 ):
     result = _impl.var(
         a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
@@ -1466,9 +1463,9 @@ def std(
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
     ddof=0,
-    keepdims=NoValue,
+    keepdims=None,
     *,
-    where: NotImplementedType = NoValue,
+    where: NotImplementedType = None,
 ):
     result = _impl.std(
         a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
@@ -1481,7 +1478,7 @@ def argmin(
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
     *,
-    keepdims=NoValue,
+    keepdims=None,
 ):
     result = _impl.argmin(a, axis=axis, keepdims=keepdims)
     return result
@@ -1492,7 +1489,7 @@ def argmax(
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
     *,
-    keepdims=NoValue,
+    keepdims=None,
 ):
     result = _impl.argmax(a, axis=axis, keepdims=keepdims)
     return result
@@ -1502,9 +1499,9 @@ def amax(
     a: ArrayLike,
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
-    initial: NotImplementedType = NoValue,
-    where: NotImplementedType = NoValue,
+    keepdims=None,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
 ):
     result = _impl.max(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
     return result
@@ -1517,9 +1514,9 @@ def amin(
     a: ArrayLike,
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
-    initial: NotImplementedType = NoValue,
-    where: NotImplementedType = NoValue,
+    keepdims=None,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
 ):
     result = _impl.min(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
     return result
@@ -1532,7 +1529,7 @@ def ptp(
     a: ArrayLike,
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
+    keepdims=None,
 ):
     result = _impl.ptp(a, axis=axis, keepdims=keepdims)
     return result
@@ -1542,9 +1539,9 @@ def all(
     a: ArrayLike,
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
+    keepdims=None,
     *,
-    where: NotImplementedType = NoValue,
+    where: NotImplementedType = None,
 ):
     result = _impl.all(a, axis=axis, where=where, keepdims=keepdims)
     return result
@@ -1554,9 +1551,9 @@ def any(
     a: ArrayLike,
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
-    keepdims=NoValue,
+    keepdims=None,
     *,
-    where: NotImplementedType = NoValue,
+    where: NotImplementedType = None,
 ):
     result = _impl.any(a, axis=axis, where=where, keepdims=keepdims)
     return result
@@ -1659,7 +1656,7 @@ def average(
     weights: ArrayLike = None,
     returned=False,
     *,
-    keepdims=NoValue,
+    keepdims=None,
 ):
     result, wsum = _impl.average(a, axis, weights, returned=returned, keepdims=keepdims)
     if returned:
@@ -1672,8 +1669,8 @@ def diff(
     a: ArrayLike,
     n=1,
     axis=-1,
-    prepend: Optional[ArrayLike] = NoValue,
-    append: Optional[ArrayLike] = NoValue,
+    prepend: Optional[ArrayLike] = None,
+    append: Optional[ArrayLike] = None,
 ):
     axis = _util.normalize_axis_index(axis, a.ndim)
 

--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -23,6 +23,7 @@ from ._normalizations import (
     AxisLike,
     DTypeLike,
     NDArray,
+    NotImplementedType,
     OutArray,
     normalize_array_like,
 )
@@ -33,12 +34,17 @@ NoValue = _util.NoValue
 ###### array creation routines
 
 
-def copy(a: ArrayLike, order: NotImplemented = "K", subok: NotImplemented = False):
+def copy(
+    a: ArrayLike, order: NotImplementedType = "K", subok: NotImplementedType = False
+):
     return a.clone()
 
 
 def copyto(
-    dst: NDArray, src: ArrayLike, casting="same_kind", where: NotImplemented = NoValue
+    dst: NDArray,
+    src: ArrayLike,
+    casting="same_kind",
+    where: NotImplementedType = NoValue,
 ):
     (src,) = _util.typecast_tensors((src,), dst.dtype, casting=casting)
     dst.copy_(src)
@@ -320,7 +326,7 @@ def arange(
     step: Optional[ArrayLike] = 1,
     dtype: DTypeLike = None,
     *,
-    like: NotImplemented = None,
+    like: NotImplementedType = None,
 ):
     if step == 0:
         raise ZeroDivisionError
@@ -365,9 +371,9 @@ def arange(
 def empty(
     shape,
     dtype: DTypeLike = float,
-    order: NotImplemented = "C",
+    order: NotImplementedType = "C",
     *,
-    like: NotImplemented = None,
+    like: NotImplementedType = None,
 ):
     if dtype is None:
         dtype = _dtypes_impl.default_float_dtype
@@ -381,8 +387,8 @@ def empty(
 def empty_like(
     prototype: ArrayLike,
     dtype: DTypeLike = None,
-    order: NotImplemented = "K",
-    subok: NotImplemented = False,
+    order: NotImplementedType = "K",
+    subok: NotImplementedType = False,
     shape=None,
 ):
     result = torch.empty_like(prototype, dtype=dtype)
@@ -395,9 +401,9 @@ def full(
     shape,
     fill_value: ArrayLike,
     dtype: DTypeLike = None,
-    order: NotImplemented = "C",
+    order: NotImplementedType = "C",
     *,
-    like: NotImplemented = None,
+    like: NotImplementedType = None,
 ):
     if isinstance(shape, int):
         shape = (shape,)
@@ -412,8 +418,8 @@ def full_like(
     a: ArrayLike,
     fill_value,
     dtype: DTypeLike = None,
-    order: NotImplemented = "K",
-    subok: NotImplemented = False,
+    order: NotImplementedType = "K",
+    subok: NotImplementedType = False,
     shape=None,
 ):
     # XXX: fill_value broadcasts
@@ -426,9 +432,9 @@ def full_like(
 def ones(
     shape,
     dtype: DTypeLike = None,
-    order: NotImplemented = "C",
+    order: NotImplementedType = "C",
     *,
-    like: NotImplemented = None,
+    like: NotImplementedType = None,
 ):
     if dtype is None:
         dtype = _dtypes_impl.default_float_dtype
@@ -438,8 +444,8 @@ def ones(
 def ones_like(
     a: ArrayLike,
     dtype: DTypeLike = None,
-    order: NotImplemented = "K",
-    subok: NotImplemented = False,
+    order: NotImplementedType = "K",
+    subok: NotImplementedType = False,
     shape=None,
 ):
     result = torch.ones_like(a, dtype=dtype)
@@ -451,9 +457,9 @@ def ones_like(
 def zeros(
     shape,
     dtype: DTypeLike = None,
-    order: NotImplemented = "C",
+    order: NotImplementedType = "C",
     *,
-    like: NotImplemented = None,
+    like: NotImplementedType = None,
 ):
     if dtype is None:
         dtype = _dtypes_impl.default_float_dtype
@@ -463,8 +469,8 @@ def zeros(
 def zeros_like(
     a: ArrayLike,
     dtype: DTypeLike = None,
-    order: NotImplemented = "K",
-    subok: NotImplemented = False,
+    order: NotImplementedType = "K",
+    subok: NotImplementedType = False,
     shape=None,
 ):
     result = torch.zeros_like(a, dtype=dtype)
@@ -647,14 +653,14 @@ def rot90(m: ArrayLike, k=1, axes=(0, 1)):
 # ### broadcasting and indices ###
 
 
-def broadcast_to(array: ArrayLike, shape, subok: NotImplemented = False):
+def broadcast_to(array: ArrayLike, shape, subok: NotImplementedType = False):
     return torch.broadcast_to(array, size=shape)
 
 
 from torch import broadcast_shapes
 
 
-def broadcast_arrays(*args: ArrayLike, subok: NotImplemented = False):
+def broadcast_arrays(*args: ArrayLike, subok: NotImplementedType = False):
     return torch.broadcast_tensors(*args)
 
 
@@ -740,7 +746,7 @@ def triu_indices_from(arr: ArrayLike, k=0):
     return tuple(result)
 
 
-def tri(N, M=None, k=0, dtype: DTypeLike = float, *, like: NotImplemented = None):
+def tri(N, M=None, k=0, dtype: DTypeLike = float, *, like: NotImplementedType = None):
     if M is None:
         M = N
     tensor = torch.ones((N, M), dtype=dtype)
@@ -758,7 +764,7 @@ def nanmean(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where: NotImplemented = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     # XXX: this needs to be rewritten
     if dtype is None:
@@ -892,7 +898,7 @@ def take(
     indices: ArrayLike,
     axis=None,
     out: Optional[OutArray] = None,
-    mode: NotImplemented = "raise",
+    mode: NotImplementedType = "raise",
 ):
     (a,), axis = _util.axis_none_ravel(a, axis=axis)
     axis = _util.normalize_axis_index(axis, a.ndim)
@@ -923,12 +929,12 @@ def put_along_axis(arr: ArrayLike, indices: ArrayLike, values: ArrayLike, axis):
 
 def unique(
     ar: ArrayLike,
-    return_index: NotImplemented = False,
+    return_index: NotImplementedType = False,
     return_inverse=False,
     return_counts=False,
     axis=None,
     *,
-    equal_nan: NotImplemented = True,
+    equal_nan: NotImplementedType = True,
 ):
     if axis is None:
         ar = ar.ravel()
@@ -1074,9 +1080,9 @@ def eye(
     M=None,
     k=0,
     dtype: DTypeLike = float,
-    order: NotImplemented = "C",
+    order: NotImplementedType = "C",
     *,
-    like: NotImplemented = None,
+    like: NotImplementedType = None,
 ):
     if M is None:
         M = N
@@ -1085,7 +1091,7 @@ def eye(
     return z
 
 
-def identity(n, dtype: DTypeLike = None, *, like: NotImplemented = None):
+def identity(n, dtype: DTypeLike = None, *, like: NotImplementedType = None):
     return torch.eye(n, dtype=dtype)
 
 
@@ -1230,14 +1236,14 @@ def _sort_helper(tensor, axis, kind, order):
     return tensor, axis, stable
 
 
-def sort(a: ArrayLike, axis=-1, kind=None, order: NotImplemented = None):
+def sort(a: ArrayLike, axis=-1, kind=None, order: NotImplementedType = None):
     # `order` keyword arg is only relevant for structured dtypes; so not supported here.
     a, axis, stable = _sort_helper(a, axis, kind, order)
     result = torch.sort(a, dim=axis, stable=stable)
     return result.values
 
 
-def argsort(a: ArrayLike, axis=-1, kind=None, order: NotImplemented = None):
+def argsort(a: ArrayLike, axis=-1, kind=None, order: NotImplementedType = None):
     a, axis, stable = _sort_helper(a, axis, kind, order)
     return torch.argsort(a, dim=axis, stable=stable)
 
@@ -1316,7 +1322,7 @@ def squeeze(a: ArrayLike, axis=None):
     return result
 
 
-def reshape(a: ArrayLike, newshape, order: NotImplemented = "C"):
+def reshape(a: ArrayLike, newshape, order: NotImplementedType = "C"):
     # if sh = (1, 2, 3), numpy allows both .reshape(sh) and .reshape(*sh)
     newshape = newshape[0] if len(newshape) == 1 else newshape
     return a.reshape(newshape)
@@ -1342,14 +1348,14 @@ def transpose(a: ArrayLike, axes=None):
     return result
 
 
-def ravel(a: ArrayLike, order: NotImplemented = "C"):
+def ravel(a: ArrayLike, order: NotImplementedType = "C"):
     return torch.ravel(a)
 
 
 # leading underscore since arr.flatten exists but np.flatten does not
 
 
-def _flatten(a: ArrayLike, order: NotImplemented = "C"):
+def _flatten(a: ArrayLike, order: NotImplementedType = "C"):
     # may return a copy
     return torch.flatten(a)
 
@@ -1398,8 +1404,8 @@ def sum(
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial: NotImplemented = NoValue,
-    where: NotImplemented = NoValue,
+    initial: NotImplementedType = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.sum(
         a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
@@ -1413,8 +1419,8 @@ def prod(
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial: NotImplemented = NoValue,
-    where: NotImplemented = NoValue,
+    initial: NotImplementedType = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.prod(
         a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
@@ -1432,7 +1438,7 @@ def mean(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where: NotImplemented = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.mean(a, axis=axis, dtype=dtype, where=NoValue, keepdims=keepdims)
     return result
@@ -1446,7 +1452,7 @@ def var(
     ddof=0,
     keepdims=NoValue,
     *,
-    where: NotImplemented = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.var(
         a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
@@ -1462,7 +1468,7 @@ def std(
     ddof=0,
     keepdims=NoValue,
     *,
-    where: NotImplemented = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.std(
         a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
@@ -1497,8 +1503,8 @@ def amax(
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial: NotImplemented = NoValue,
-    where: NotImplemented = NoValue,
+    initial: NotImplementedType = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.max(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
     return result
@@ -1512,8 +1518,8 @@ def amin(
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial: NotImplemented = NoValue,
-    where: NotImplemented = NoValue,
+    initial: NotImplementedType = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.min(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
     return result
@@ -1538,7 +1544,7 @@ def all(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where: NotImplemented = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.all(a, axis=axis, where=where, keepdims=keepdims)
     return result
@@ -1550,7 +1556,7 @@ def any(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where: NotImplemented = NoValue,
+    where: NotImplementedType = NoValue,
 ):
     result = _impl.any(a, axis=axis, where=where, keepdims=keepdims)
     return result
@@ -1593,7 +1599,7 @@ def quantile(
     method="linear",
     keepdims=False,
     *,
-    interpolation: NotImplemented = None,
+    interpolation: NotImplementedType = None,
 ):
     result = _impl.quantile(
         a,
@@ -1616,7 +1622,7 @@ def percentile(
     method="linear",
     keepdims=False,
     *,
-    interpolation: NotImplemented = None,
+    interpolation: NotImplementedType = None,
 ):
     result = _impl.percentile(
         a,

--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -24,7 +24,6 @@ from ._normalizations import (
     DTypeLike,
     NDArray,
     OutArray,
-    SubokLike,
     normalize_array_like,
 )
 
@@ -34,15 +33,13 @@ NoValue = _util.NoValue
 ###### array creation routines
 
 
-def copy(a: ArrayLike, order="K", subok: SubokLike = False):
-    if order != "K":
-        raise NotImplementedError
+def copy(a: ArrayLike, order: NotImplemented = "K", subok: NotImplemented = False):
     return a.clone()
 
 
-def copyto(dst: NDArray, src: ArrayLike, casting="same_kind", where=NoValue):
-    if where is not NoValue:
-        raise NotImplementedError
+def copyto(
+    dst: NDArray, src: ArrayLike, casting="same_kind", where: NotImplemented = NoValue
+):
     (src,) = _util.typecast_tensors((src,), dst.dtype, casting=casting)
     dst.copy_(src)
 
@@ -323,7 +320,7 @@ def arange(
     step: Optional[ArrayLike] = 1,
     dtype: DTypeLike = None,
     *,
-    like: SubokLike = None,
+    like: NotImplemented = None,
 ):
     if step == 0:
         raise ZeroDivisionError
@@ -365,9 +362,13 @@ def arange(
 # ### zeros/ones/empty/full ###
 
 
-def empty(shape, dtype: DTypeLike = float, order="C", *, like: SubokLike = None):
-    if order != "C":
-        raise NotImplementedError
+def empty(
+    shape,
+    dtype: DTypeLike = float,
+    order: NotImplemented = "C",
+    *,
+    like: NotImplemented = None,
+):
     if dtype is None:
         dtype = _dtypes_impl.default_float_dtype
     return torch.empty(shape, dtype=dtype)
@@ -380,12 +381,10 @@ def empty(shape, dtype: DTypeLike = float, order="C", *, like: SubokLike = None)
 def empty_like(
     prototype: ArrayLike,
     dtype: DTypeLike = None,
-    order="K",
-    subok: SubokLike = False,
+    order: NotImplemented = "K",
+    subok: NotImplemented = False,
     shape=None,
 ):
-    if order != "K":
-        raise NotImplementedError
     result = torch.empty_like(prototype, dtype=dtype)
     if shape is not None:
         result = result.reshape(shape)
@@ -396,14 +395,12 @@ def full(
     shape,
     fill_value: ArrayLike,
     dtype: DTypeLike = None,
-    order="C",
+    order: NotImplemented = "C",
     *,
-    like: SubokLike = None,
+    like: NotImplemented = None,
 ):
     if isinstance(shape, int):
         shape = (shape,)
-    if order != "C":
-        raise NotImplementedError
     if dtype is None:
         dtype = fill_value.dtype
     if not isinstance(shape, (tuple, list)):
@@ -415,12 +412,10 @@ def full_like(
     a: ArrayLike,
     fill_value,
     dtype: DTypeLike = None,
-    order="K",
-    subok: SubokLike = False,
+    order: NotImplemented = "K",
+    subok: NotImplemented = False,
     shape=None,
 ):
-    if order != "K":
-        raise NotImplementedError
     # XXX: fill_value broadcasts
     result = torch.full_like(a, fill_value, dtype=dtype)
     if shape is not None:
@@ -428,9 +423,13 @@ def full_like(
     return result
 
 
-def ones(shape, dtype: DTypeLike = None, order="C", *, like: SubokLike = None):
-    if order != "C":
-        raise NotImplementedError
+def ones(
+    shape,
+    dtype: DTypeLike = None,
+    order: NotImplemented = "C",
+    *,
+    like: NotImplemented = None,
+):
     if dtype is None:
         dtype = _dtypes_impl.default_float_dtype
     return torch.ones(shape, dtype=dtype)
@@ -439,21 +438,23 @@ def ones(shape, dtype: DTypeLike = None, order="C", *, like: SubokLike = None):
 def ones_like(
     a: ArrayLike,
     dtype: DTypeLike = None,
-    order="K",
-    subok: SubokLike = False,
+    order: NotImplemented = "K",
+    subok: NotImplemented = False,
     shape=None,
 ):
-    if order != "K":
-        raise NotImplementedError
     result = torch.ones_like(a, dtype=dtype)
     if shape is not None:
         result = result.reshape(shape)
     return result
 
 
-def zeros(shape, dtype: DTypeLike = None, order="C", *, like: SubokLike = None):
-    if order != "C":
-        raise NotImplementedError
+def zeros(
+    shape,
+    dtype: DTypeLike = None,
+    order: NotImplemented = "C",
+    *,
+    like: NotImplemented = None,
+):
     if dtype is None:
         dtype = _dtypes_impl.default_float_dtype
     return torch.zeros(shape, dtype=dtype)
@@ -462,12 +463,10 @@ def zeros(shape, dtype: DTypeLike = None, order="C", *, like: SubokLike = None):
 def zeros_like(
     a: ArrayLike,
     dtype: DTypeLike = None,
-    order="K",
-    subok: SubokLike = False,
+    order: NotImplemented = "K",
+    subok: NotImplemented = False,
     shape=None,
 ):
-    if order != "K":
-        raise NotImplementedError
     result = torch.zeros_like(a, dtype=dtype)
     if shape is not None:
         result = result.reshape(shape)
@@ -648,14 +647,14 @@ def rot90(m: ArrayLike, k=1, axes=(0, 1)):
 # ### broadcasting and indices ###
 
 
-def broadcast_to(array: ArrayLike, shape, subok: SubokLike = False):
+def broadcast_to(array: ArrayLike, shape, subok: NotImplemented = False):
     return torch.broadcast_to(array, size=shape)
 
 
 from torch import broadcast_shapes
 
 
-def broadcast_arrays(*args: ArrayLike, subok: SubokLike = False):
+def broadcast_arrays(*args: ArrayLike, subok: NotImplemented = False):
     return torch.broadcast_tensors(*args)
 
 
@@ -741,7 +740,7 @@ def triu_indices_from(arr: ArrayLike, k=0):
     return tuple(result)
 
 
-def tri(N, M=None, k=0, dtype: DTypeLike = float, *, like: SubokLike = None):
+def tri(N, M=None, k=0, dtype: DTypeLike = float, *, like: NotImplemented = None):
     if M is None:
         M = N
     tensor = torch.ones((N, M), dtype=dtype)
@@ -759,11 +758,9 @@ def nanmean(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where=NoValue,
+    where: NotImplemented = NoValue,
 ):
     # XXX: this needs to be rewritten
-    if where is not NoValue:
-        raise NotImplementedError
     if dtype is None:
         dtype = a.dtype
     if axis is None:
@@ -895,11 +892,8 @@ def take(
     indices: ArrayLike,
     axis=None,
     out: Optional[OutArray] = None,
-    mode="raise",
+    mode: NotImplemented = "raise",
 ):
-    if mode != "raise":
-        raise NotImplementedError(f"{mode=}")
-
     (a,), axis = _util.axis_none_ravel(a, axis=axis)
     axis = _util.normalize_axis_index(axis, a.ndim)
     idx = (slice(None),) * axis + (indices, ...)
@@ -929,16 +923,13 @@ def put_along_axis(arr: ArrayLike, indices: ArrayLike, values: ArrayLike, axis):
 
 def unique(
     ar: ArrayLike,
-    return_index=False,
+    return_index: NotImplemented = False,
     return_inverse=False,
     return_counts=False,
     axis=None,
     *,
-    equal_nan=True,
+    equal_nan: NotImplemented = True,
 ):
-    if return_index or not equal_nan:
-        raise NotImplementedError
-
     if axis is None:
         ar = ar.ravel()
         axis = 0
@@ -1078,9 +1069,15 @@ def trace(
     return result
 
 
-def eye(N, M=None, k=0, dtype: DTypeLike = float, order="C", *, like: SubokLike = None):
-    if order != "C":
-        raise NotImplementedError
+def eye(
+    N,
+    M=None,
+    k=0,
+    dtype: DTypeLike = float,
+    order: NotImplemented = "C",
+    *,
+    like: NotImplemented = None,
+):
     if M is None:
         M = N
     z = torch.zeros(N, M, dtype=dtype)
@@ -1088,7 +1085,7 @@ def eye(N, M=None, k=0, dtype: DTypeLike = float, order="C", *, like: SubokLike 
     return z
 
 
-def identity(n, dtype: DTypeLike = None, *, like: SubokLike = None):
+def identity(n, dtype: DTypeLike = None, *, like: NotImplemented = None):
     return torch.eye(n, dtype=dtype)
 
 
@@ -1225,12 +1222,6 @@ def outer(a: ArrayLike, b: ArrayLike, out: Optional[OutArray] = None):
 
 
 def _sort_helper(tensor, axis, kind, order):
-    if order is not None:
-        # only relevant for structured dtypes; not supported
-        raise NotImplementedError(
-            "'order' keyword is only relevant for structured dtypes"
-        )
-
     (tensor,), axis = _util.axis_none_ravel(tensor, axis=axis)
     axis = _util.normalize_axis_index(axis, tensor.ndim)
 
@@ -1239,13 +1230,14 @@ def _sort_helper(tensor, axis, kind, order):
     return tensor, axis, stable
 
 
-def sort(a: ArrayLike, axis=-1, kind=None, order=None):
+def sort(a: ArrayLike, axis=-1, kind=None, order: NotImplemented = None):
+    # `order` keyword arg is only relevant for structured dtypes; so not supported here.
     a, axis, stable = _sort_helper(a, axis, kind, order)
     result = torch.sort(a, dim=axis, stable=stable)
     return result.values
 
 
-def argsort(a: ArrayLike, axis=-1, kind=None, order=None):
+def argsort(a: ArrayLike, axis=-1, kind=None, order: NotImplemented = None):
     a, axis, stable = _sort_helper(a, axis, kind, order)
     return torch.argsort(a, dim=axis, stable=stable)
 
@@ -1324,9 +1316,7 @@ def squeeze(a: ArrayLike, axis=None):
     return result
 
 
-def reshape(a: ArrayLike, newshape, order="C"):
-    if order != "C":
-        raise NotImplementedError
+def reshape(a: ArrayLike, newshape, order: NotImplemented = "C"):
     # if sh = (1, 2, 3), numpy allows both .reshape(sh) and .reshape(*sh)
     newshape = newshape[0] if len(newshape) == 1 else newshape
     return a.reshape(newshape)
@@ -1352,18 +1342,14 @@ def transpose(a: ArrayLike, axes=None):
     return result
 
 
-def ravel(a: ArrayLike, order="C"):
-    if order != "C":
-        raise NotImplementedError
+def ravel(a: ArrayLike, order: NotImplemented = "C"):
     return torch.ravel(a)
 
 
 # leading underscore since arr.flatten exists but np.flatten does not
 
 
-def _flatten(a: ArrayLike, order="C"):
-    if order != "C":
-        raise NotImplementedError
+def _flatten(a: ArrayLike, order: NotImplemented = "C"):
     # may return a copy
     return torch.flatten(a)
 
@@ -1412,8 +1398,8 @@ def sum(
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial=NoValue,
-    where=NoValue,
+    initial: NotImplemented = NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.sum(
         a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
@@ -1427,8 +1413,8 @@ def prod(
     dtype: DTypeLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial=NoValue,
-    where=NoValue,
+    initial: NotImplemented = NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.prod(
         a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
@@ -1446,7 +1432,7 @@ def mean(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where=NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.mean(a, axis=axis, dtype=dtype, where=NoValue, keepdims=keepdims)
     return result
@@ -1460,7 +1446,7 @@ def var(
     ddof=0,
     keepdims=NoValue,
     *,
-    where=NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.var(
         a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
@@ -1476,7 +1462,7 @@ def std(
     ddof=0,
     keepdims=NoValue,
     *,
-    where=NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.std(
         a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
@@ -1511,8 +1497,8 @@ def amax(
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial=NoValue,
-    where=NoValue,
+    initial: NotImplemented = NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.max(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
     return result
@@ -1526,8 +1512,8 @@ def amin(
     axis: AxisLike = None,
     out: Optional[OutArray] = None,
     keepdims=NoValue,
-    initial=NoValue,
-    where=NoValue,
+    initial: NotImplemented = NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.min(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
     return result
@@ -1552,7 +1538,7 @@ def all(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where=NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.all(a, axis=axis, where=where, keepdims=keepdims)
     return result
@@ -1564,7 +1550,7 @@ def any(
     out: Optional[OutArray] = None,
     keepdims=NoValue,
     *,
-    where=NoValue,
+    where: NotImplemented = NoValue,
 ):
     result = _impl.any(a, axis=axis, where=where, keepdims=keepdims)
     return result
@@ -1607,7 +1593,7 @@ def quantile(
     method="linear",
     keepdims=False,
     *,
-    interpolation=None,
+    interpolation: NotImplemented = None,
 ):
     result = _impl.quantile(
         a,
@@ -1630,7 +1616,7 @@ def percentile(
     method="linear",
     keepdims=False,
     *,
-    interpolation=None,
+    interpolation: NotImplemented = None,
 ):
     result = _impl.percentile(
         a,

--- a/torch_np/_normalizations.py
+++ b/torch_np/_normalizations.py
@@ -28,6 +28,11 @@ NDArray = typing.TypeVar("NDarray")
 #
 OutArray = typing.TypeVar("OutArray")
 
+try:
+    from typing import NotImplementedType
+except ImportError:
+    NotImplementedType = typing.TypeVar("NotImplementedType")
+
 
 import inspect
 
@@ -105,7 +110,7 @@ normalizers = {
     "NDArray": normalize_ndarray,
     "DTypeLike": normalize_dtype,
     "AxisLike": normalize_axis_like,
-    NotImplemented: normalize_not_implemented,
+    "NotImplementedType": normalize_not_implemented,
 }
 
 

--- a/torch_np/_ufuncs.py
+++ b/torch_np/_ufuncs.py
@@ -6,13 +6,10 @@ import torch
 
 from . import _binary_ufuncs_impl, _helpers, _unary_ufuncs_impl
 from ._detail import _dtypes_impl, _util
-from ._normalizations import ArrayLike, DTypeLike, OutArray, SubokLike, normalizer
+from ._normalizations import ArrayLike, DTypeLike, OutArray, normalizer
 
 
 def _ufunc_preprocess(tensors, where, casting, order, dtype, subok, signature, extobj):
-    if order != "K" or not where or signature or extobj:
-        raise NotImplementedError
-
     if dtype is None:
         dtype = _dtypes_impl.result_type_impl([t.dtype for t in tensors])
 
@@ -54,7 +51,7 @@ def deco_binary_ufunc(torch_func):
         casting="same_kind",
         order="K",
         dtype: DTypeLike = None,
-        subok: SubokLike = False,
+        subok: NotImplemented = False,
         signature=None,
         extobj=None,
     ):
@@ -85,20 +82,17 @@ def matmul(
     out: Optional[OutArray] = None,
     *,
     casting="same_kind",
-    order="K",
+    order: NotImplemented = "K",
     dtype: DTypeLike = None,
-    subok: SubokLike = False,
-    signature=None,
-    extobj=None,
-    axes=None,
-    axis=None,
+    subok: NotImplemented = False,
+    signature: NotImplemented = None,
+    extobj: NotImplemented = None,
+    axes: NotImplemented = None,
+    axis: NotImplemented = None,
 ):
     tensors = _ufunc_preprocess(
         (x1, x2), True, casting, order, dtype, subok, signature, extobj
     )
-    if axis is not None or axes is not None:
-        raise NotImplementedError
-
     result = _binary_ufuncs_impl.matmul(*tensors)
 
     result = _ufunc_postprocess(result, out, casting)
@@ -117,13 +111,13 @@ def divmod(
     /,
     out: tuple[Optional[OutArray], Optional[OutArray]] = (None, None),
     *,
-    where=True,
+    where: NotImplemented = True,
     casting="same_kind",
-    order="K",
+    order: NotImplemented = "K",
     dtype: DTypeLike = None,
-    subok: SubokLike = False,
-    signature=None,
-    extobj=None,
+    subok: NotImplemented = False,
+    signature: NotImplemented = None,
+    extobj: NotImplemented = None,
 ):
     # make sure we either have no out arrays at all, or there is either
     # out1, out2, or out=tuple, but not both
@@ -194,7 +188,7 @@ def deco_unary_ufunc(torch_func):
         casting="same_kind",
         order="K",
         dtype: DTypeLike = None,
-        subok: SubokLike = False,
+        subok: NotImplemented = False,
         signature=None,
         extobj=None,
     ):

--- a/torch_np/_ufuncs.py
+++ b/torch_np/_ufuncs.py
@@ -6,7 +6,13 @@ import torch
 
 from . import _binary_ufuncs_impl, _helpers, _unary_ufuncs_impl
 from ._detail import _dtypes_impl, _util
-from ._normalizations import ArrayLike, DTypeLike, OutArray, normalizer
+from ._normalizations import (
+    ArrayLike,
+    DTypeLike,
+    NotImplementedType,
+    OutArray,
+    normalizer,
+)
 
 
 def _ufunc_preprocess(tensors, where, casting, order, dtype, subok, signature, extobj):
@@ -51,7 +57,7 @@ def deco_binary_ufunc(torch_func):
         casting="same_kind",
         order="K",
         dtype: DTypeLike = None,
-        subok: NotImplemented = False,
+        subok: NotImplementedType = False,
         signature=None,
         extobj=None,
     ):
@@ -82,13 +88,13 @@ def matmul(
     out: Optional[OutArray] = None,
     *,
     casting="same_kind",
-    order: NotImplemented = "K",
+    order: NotImplementedType = "K",
     dtype: DTypeLike = None,
-    subok: NotImplemented = False,
-    signature: NotImplemented = None,
-    extobj: NotImplemented = None,
-    axes: NotImplemented = None,
-    axis: NotImplemented = None,
+    subok: NotImplementedType = False,
+    signature: NotImplementedType = None,
+    extobj: NotImplementedType = None,
+    axes: NotImplementedType = None,
+    axis: NotImplementedType = None,
 ):
     tensors = _ufunc_preprocess(
         (x1, x2), True, casting, order, dtype, subok, signature, extobj
@@ -111,13 +117,13 @@ def divmod(
     /,
     out: tuple[Optional[OutArray], Optional[OutArray]] = (None, None),
     *,
-    where: NotImplemented = True,
+    where: NotImplementedType = True,
     casting="same_kind",
-    order: NotImplemented = "K",
+    order: NotImplementedType = "K",
     dtype: DTypeLike = None,
-    subok: NotImplemented = False,
-    signature: NotImplemented = None,
-    extobj: NotImplemented = None,
+    subok: NotImplementedType = False,
+    signature: NotImplementedType = None,
+    extobj: NotImplementedType = None,
 ):
     # make sure we either have no out arrays at all, or there is either
     # out1, out2, or out=tuple, but not both
@@ -188,7 +194,7 @@ def deco_unary_ufunc(torch_func):
         casting="same_kind",
         order="K",
         dtype: DTypeLike = None,
-        subok: NotImplemented = False,
+        subok: NotImplementedType = False,
         signature=None,
         extobj=None,
     ):

--- a/torch_np/_ufuncs.py
+++ b/torch_np/_ufuncs.py
@@ -47,6 +47,7 @@ def deco_binary_ufunc(torch_func):
     the pytorch functions for the actual work.
     """
 
+    @normalizer
     def wrapped(
         x1: ArrayLike,
         x2: ArrayLike,
@@ -151,13 +152,11 @@ def divmod(
 
 
 #
-# For each torch ufunc implementation, decorate and attach the decorated name
-# to this module. Its contents is then exported to the public namespace in __init__.py
+# Attach ufuncs to this module, for a further export to the public namespace in __init__.py
 #
 for name in _binary:
     ufunc = getattr(_binary_ufuncs_impl, name)
-    decorated = normalizer(deco_binary_ufunc(ufunc))
-    vars()[name] = decorated
+    vars()[name] = deco_binary_ufunc(ufunc)
 
 
 def modf(x, /, *args, **kwds):
@@ -185,6 +184,7 @@ def deco_unary_ufunc(torch_func):
     the pytorch functions for the actual work.
     """
 
+    @normalizer
     def wrapped(
         x: ArrayLike,
         /,
@@ -212,13 +212,11 @@ def deco_unary_ufunc(torch_func):
 
 
 #
-# For each torch ufunc implementation, decorate and attach the decorated name
-# to this module. Its contents is then exported to the public namespace in __init__.py
+# Attach ufuncs to this module, for a further export to the public namespace in __init__.py
 #
 for name in _unary:
     ufunc = getattr(_unary_ufuncs_impl, name)
-    decorated = normalizer(deco_unary_ufunc(ufunc))
-    vars()[name] = decorated
+    vars()[name] = deco_unary_ufunc(ufunc)
 
 
 __all__ = _binary + _unary

--- a/torch_np/tests/test_basic.py
+++ b/torch_np/tests/test_basic.py
@@ -500,3 +500,10 @@ class TestDivmod:
         o = w.empty(1)
         with assert_raises(TypeError):
             w.divmod(1, 2, o, o, out=(o, o))
+
+
+class TestSmokeNotImpl:
+    def test_basic(self):
+        # smoke test that the "NotImplemented" annotation is picked up
+        with assert_raises(NotImplementedError):
+            w.empty(3, like="ooops")


### PR DESCRIPTION
as discussed in https://github.com/Quansight-Labs/numpy_pytorch_interop/pull/112#discussion_r1162861446

This does seem to gain a marginal LOC reduction and some possible readability improvement. Two points:

- I'm {ab,re}using the `NotImplemented` singleton as the annotation. Introducing a new `NotImplementedType` is a bit awkward since `typing.NotImplementedType` is a thing from python 3.10, and we need to cover 3.8+. A simple alternative is to just use `type(NotImplemented)` instead of `NotImplemented`. Don't have a firm opinion, am open to suggestions.

- NumPy uses a weird `_NoValue` sentinel in some cases; we mimicked it by defining an alias `NoValue = None`. In our usage we typically raise NotImplementedError on things with the `NoValue` default. Now that we have a dedicated annotation, `NoValue` alias seems extraneous. Anyone sees a need for it?