### PR TITLE
Simplify registartion of methods in ndarray

### DIFF
--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -124,7 +124,6 @@ ri_dunder = {
     "mul": "multiply",
     "truediv": "divide",
     "floordiv": "floor_divide",
-    "divmod": None,
     "pow": "float_power",
     "mod": "remainder",
     "and": "bitwise_and",
@@ -175,6 +174,12 @@ class ndarray:
         vars()[ivar] = create_method(
             lambda self, other, fn=fn: fn(self, other, out=self), ivar
         )
+
+    # There's no __idivmod__
+    __divmod__ = create_method(_ufuncs.divmod, "__divmod__")
+    __rdivmod__ = create_method(
+        lambda self, other: _ufuncs.divmod(other, self), "__rdivmod__"
+    )
 
     @property
     def shape(self):

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -67,6 +67,7 @@ def create_method(fn, name=None):
     f.__qualname__ = f"ndarray.{name}"
     return f
 
+
 # Map ndarray.name_method -> np.name_func
 # If name_func == None, it means that name_method == name_func
 methods = {
@@ -137,6 +138,7 @@ ri_dunder = {
 
 ##################### ndarray class ###########################
 
+
 class ndarray:
     def __init__(self, t=None):
         if t is None:
@@ -170,7 +172,9 @@ class ndarray:
         rvar = f"__r{method}__"
         vars()[rvar] = create_method(lambda self, other, fn=fn: fn(other, self), rvar)
         ivar = f"__i{method}__"
-        vars()[ivar] = create_method(lambda self, other, fn=fn: fn(self, other, out=self), ivar)
+        vars()[ivar] = create_method(
+            lambda self, other, fn=fn: fn(self, other, out=self), ivar
+        )
 
     @property
     def shape(self):
@@ -384,6 +388,7 @@ class ndarray:
         index = ndarray._upcast_int_indices(index)
         value = _helpers.ndarrays_to_tensors(value)
         return self.tensor.__setitem__(index, value)
+
 
 # This is the ideally the only place which talks to ndarray directly.
 # The rest goes through asarray (preferred) or array.

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -107,7 +107,7 @@ methods = {
 }
 
 dunder = {
-    "abs": "invert",
+    "abs": "absolute",
     "invert": None,
     "pos": "positive",
     "neg": "negative",


### PR DESCRIPTION
This PR makes the registration of methods in `ndarray` uniform. It also corrects their `__name__` and `__qualname__` attributes.

While doing this, we fix many r-looking dunder methods that were not correctly implemented see e.g.
https://github.com/Quansight-Labs/numpy_pytorch_interop/pull/2#discussion_r1162547828. We also add the variants of `divmod`, which were missing.