### PR TITLE
Fix fill_diagonal

### DIFF
--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -1118,30 +1118,36 @@ def diag_indices_from(arr: ArrayLike):
 
 
 def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap=False):
-    # torch.Tensor.fill_diagonal_ only accepts scalars. Thus vendor the numpy source,
-    # https://github.com/numpy/numpy/blob/v1.24.0/numpy/lib/index_tricks.py#L786-L917
-
     if a.ndim < 2:
         raise ValueError("array must be at least 2-d")
-    end = None
-    if a.ndim == 2:
-        # Explicit, fast formula for the common case.  For 2-d arrays, we
-        # accept rectangular ones.
-        step = a.shape[1] + 1
-        # This is needed to don't have tall matrix have the diagonal wrap.
-        if not wrap:
-            end = a.shape[1] * a.shape[1]
-    else:
-        # For more than d=2, the strided formula is only valid for arrays with
-        # all dimensions equal, so we check first.
-        s = a.shape
-        if s[1:] != s[:-1]:
-            raise ValueError("All dimensions of input must be of equal length")
-        sz = torch.as_tensor(a.shape[:-1])
-        step = 1 + (torch.cumprod(sz, 0)).sum()
+    if val.numel() == 0 and not wrap:
+        a.fill_diagonal_(val)
+        return a
 
-    # Write the value out into the diagonal.
-    a.ravel()[:end:step] = val
+    if val.ndim == 0:
+        val = val.unsqueeze(0)
+
+    # torch.Tensor.fill_diagonal_ only accepts scalars
+    # If the size of val is too large, then val is trimmed
+    if a.ndim == 2:
+        tall = a.shape[0] > a.shape[1]
+        # wrap does nothing for wide matrices...
+        if not wrap or not tall:
+            # Never wraps
+            diag = a.diagonal()
+            diag.copy_(val[:diag.numel()])
+        else:
+            # wraps and tall... leaving one empty line between diagonals?!
+            max_, min_ = a.shape
+            idx = torch.arange(max_ - max_ // (min_ + 1))
+            mod = idx % min_
+            div = idx // min_
+            a[(div * (min_ + 1) + mod, mod)] = val[:idx.numel()]
+    else:
+        idx = diag_indices_from(a)
+        # a.shape = (n, n, ..., n)
+        a[idx] = val[:a.shape[0]]
+
     return a
 
 
@@ -1174,7 +1180,7 @@ def vdot(a: ArrayLike, b: ArrayLike, /):
     elif is_bool:
         result = result.to(torch.bool)
 
-    return result.item()
+    return result
 
 
 def tensordot(a: ArrayLike, b: ArrayLike, axes=2):


### PR DESCRIPTION
fill_diagonal had an implementation that assumed that `.ravel()` returns a view onto the original tensor. This is not true, as there are many tensors that cannot be flattened. `x.flat` in NumPy returns an iterator that iterates the elements "in order". We do not have anything like that in PyTorch. This PR implements this operation via some rather funky advanced indexing. The `wrap` kwarg is... weird to say the least...