### PR TITLE
Assorted fixes and simplifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 __pycache__/
 *.py[cod]
 .coverage
+.hypothesis
 

--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -71,14 +71,16 @@ def atleast_3d(*arys: ArrayLike):
 
 
 def _concat_check(tup, dtype, out):
+    if tup == ():
+        raise ValueError("need at least one array to concatenate")
+
     """Check inputs in concatenate et al."""
-    if out is not None:
-        if dtype is not None:
-            # mimic numpy
-            raise TypeError(
-                "concatenate() only takes `out` or `dtype` as an "
-                "argument, but both were provided."
-            )
+    if out is not None and dtype is not None:
+        # mimic numpy
+        raise TypeError(
+            "concatenate() only takes `out` or `dtype` as an "
+            "argument, but both were provided."
+        )
 
 
 def _concat_cast_helper(tensors, out=None, dtype=None, casting="same_kind"):
@@ -343,6 +345,11 @@ def arange(
 
     # work around RuntimeError: "arange_cpu" not implemented for 'ComplexFloat'
     work_dtype = torch.float64 if target_dtype.is_complex else target_dtype
+
+    if (step > 0 and start > stop) or (step < 0 and start < stop):
+        # empty range
+        return torch.empty(0, dtype=target_dtype)
+
     result = torch.arange(start, stop, step, dtype=work_dtype)
     result = _util.cast_if_needed(result, target_dtype)
     return result

--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -1686,6 +1686,7 @@ def round(a: ArrayLike, decimals=0, out: Optional[OutArray] = None):
 
 
 around = round
+round_ = round
 
 
 def real_if_close(a: ArrayLike, tol=100):

--- a/torch_np/tests/numpy_tests/core/test_multiarray.py
+++ b/torch_np/tests/numpy_tests/core/test_multiarray.py
@@ -1532,9 +1532,9 @@ class TestMethods:
     def test_transpose(self):
         a = np.array([[1, 2], [3, 4]])
         assert_equal(a.transpose(), [[1, 3], [2, 4]])
-        assert_raises(ValueError, lambda: a.transpose(0))
-        assert_raises(ValueError, lambda: a.transpose(0, 0))
-        assert_raises(ValueError, lambda: a.transpose(0, 1, 2))
+        assert_raises((RuntimeError, ValueError), lambda: a.transpose(0))
+        assert_raises((RuntimeError, ValueError), lambda: a.transpose(0, 0))
+        assert_raises((RuntimeError, ValueError), lambda: a.transpose(0, 1, 2))
 
     def test_sort(self):
         # test ordering for floats and complex containing nans. It is only
@@ -7270,8 +7270,8 @@ class TestWhere:
         c = [True, True]
         a = np.ones((4, 5))
         b = np.ones((5, 5))
-        assert_raises(ValueError, np.where, c, a, a)
-        assert_raises(ValueError, np.where, c[0], a, b)
+        assert_raises((RuntimeError, ValueError), np.where, c, a, a)
+        assert_raises((RuntimeError, ValueError), np.where, c[0], a, b)
 
     def test_empty_result(self):
         # pass empty where result through an assignment which reads the data of
@@ -7497,14 +7497,14 @@ class TestWritebackIfCopy:
 
 class TestArange:
     def test_infinite(self):
-        assert_raises_regex(
-            ValueError, "size exceeded",
+        assert_raises(
+            (RuntimeError, ValueError),  # "unsupported range",
             np.arange, 0, np.inf
         )
 
     def test_nan_step(self):
         assert_raises(
-            ValueError, # "cannot compute length",
+            (RuntimeError, ValueError),  # "cannot compute length",
             np.arange, 0, 1, np.nan
         )
 

--- a/torch_np/tests/numpy_tests/core/test_shape_base.py
+++ b/torch_np/tests/numpy_tests/core/test_shape_base.py
@@ -256,16 +256,16 @@ class TestConcatenate:
         for ndim in [1, 2, 3]:
             a = np.ones((1,)*ndim)
             np.concatenate((a, a), axis=0)  # OK
-            assert_raises(np.AxisError, np.concatenate, (a, a), axis=ndim)
-            assert_raises(np.AxisError, np.concatenate, (a, a), axis=-(ndim + 1))
+            assert_raises((IndexError, np.AxisError), np.concatenate, (a, a), axis=ndim)
+            assert_raises((IndexError, np.AxisError), np.concatenate, (a, a), axis=-(ndim + 1))
 
         # Scalars cannot be concatenated
-        assert_raises(ValueError, concatenate, (0,))
-        assert_raises(ValueError, concatenate, (np.array(0),))
+        assert_raises((RuntimeError, ValueError), concatenate, (0,))
+        assert_raises((RuntimeError, ValueError), concatenate, (np.array(0),))
 
         # dimensionality must match
         assert_raises(
-            ValueError,
+            (RuntimeError, ValueError),
             #        assert_raises_regex(
             #            ValueError,
             #            r"all the input arrays must have same number of dimensions, but "
@@ -283,7 +283,7 @@ class TestConcatenate:
             np.concatenate((a, b), axis=axis[0])  # OK
             #            assert_raises_regex(
             assert_raises(
-                ValueError,
+                (RuntimeError, ValueError),
                 #                "all the input array dimensions except for the concatenation axis "
                 #                "must match exactly, but along dimension {}, the array at "
                 #                "index 0 has size 1 and the array at index 1 has size 2"
@@ -292,7 +292,7 @@ class TestConcatenate:
                 (a, b),
                 axis=axis[1],
             )
-            assert_raises(ValueError, np.concatenate, (a, b), axis=axis[2])
+            assert_raises((RuntimeError, ValueError), np.concatenate, (a, b), axis=axis[2])
             a = np.moveaxis(a, -1, 0)
             b = np.moveaxis(b, -1, 0)
             axis.append(axis.pop(0))
@@ -359,7 +359,7 @@ class TestConcatenate:
         assert_array_equal(concatenate((a23.T, a13.T), 1), res.T)
         assert_array_equal(concatenate((a23.T, a13.T), -1), res.T)
         # Arrays much match shape
-        assert_raises(ValueError, concatenate, (a23.T, a13.T), 0)
+        assert_raises((RuntimeError, ValueError), concatenate, (a23.T, a13.T), 0)
         # 3D
         res = np.arange(2 * 3 * 7).reshape((2, 3, 7))
         a0 = res[..., :4]
@@ -474,11 +474,11 @@ def test_stack():
     # edge cases
     assert_raises(ValueError, stack, [])
     assert_raises(ValueError, stack, [])
-    assert_raises(ValueError, stack, [1, np.arange(3)])
-    assert_raises(ValueError, stack, [np.arange(3), 1])
-    assert_raises(ValueError, stack, [np.arange(3), 1], axis=1)
-    assert_raises(ValueError, stack, [np.zeros((3, 3)), np.zeros(3)], axis=1)
-    assert_raises(ValueError, stack, [np.arange(2), np.arange(3)])
+    assert_raises((RuntimeError, ValueError), stack, [1, np.arange(3)])
+    assert_raises((RuntimeError, ValueError), stack, [np.arange(3), 1])
+    assert_raises((RuntimeError, ValueError), stack, [np.arange(3), 1], axis=1)
+    assert_raises((RuntimeError, ValueError), stack, [np.zeros((3, 3)), np.zeros(3)], axis=1)
+    assert_raises((RuntimeError, ValueError), stack, [np.arange(2), np.arange(3)])
 
     # generator is deprecated: numpy 1.24 emits a warning but we don't
     # with assert_warns(FutureWarning):

--- a/torch_np/tests/test_basic.py
+++ b/torch_np/tests/test_basic.py
@@ -104,7 +104,6 @@ one_arg_axis_funcs = [
     w.all,
     w.any,
     w.mean,
-    w.nanmean,
     w.argsort,
     w.std,
     w.var,

--- a/torch_np/tests/test_basic.py
+++ b/torch_np/tests/test_basic.py
@@ -33,7 +33,7 @@ one_arg_funcs = [
     w.i0,
     w.copy,
     w.array,
-    w.round_,
+    w.round,
     w.around,
     w.flip,
     w.vstack,

--- a/torch_np/tests/test_basic.py
+++ b/torch_np/tests/test_basic.py
@@ -335,7 +335,13 @@ class TestSequenceOfArraysToSingle:
         assert isinstance(result, w.ndarray)
 
 
-single_to_seq_funcs = [w.nonzero, w.tril_indices_from, w.triu_indices_from, w.where]
+single_to_seq_funcs = (
+    w.nonzero,
+    # https://github.com/Quansight-Labs/numpy_pytorch_interop/pull/121#discussion_r1172824545
+    # w.tril_indices_from,
+    # w.triu_indices_from,
+    w.where,
+)
 
 
 @pytest.mark.parametrize("func", single_to_seq_funcs)

--- a/torch_np/tests/test_function_base.py
+++ b/torch_np/tests/test_function_base.py
@@ -7,10 +7,14 @@ from torch_np.testing import assert_array_equal, assert_equal
 
 class TestArange:
     def test_infinite(self):
-        assert_raises(ValueError, np.arange, 0, np.inf)  # "size exceeded",
+        assert_raises(
+            (RuntimeError, ValueError), np.arange, 0, np.inf
+        )  # "size exceeded",
 
     def test_nan_step(self):
-        assert_raises(ValueError, np.arange, 0, 1, np.nan)  # "cannot compute length",
+        assert_raises(
+            (RuntimeError, ValueError), np.arange, 0, 1, np.nan
+        )  # "cannot compute length",
 
     def test_zero_step(self):
         assert_raises(ZeroDivisionError, np.arange, 0, 10, 0)

--- a/torch_np/tests/test_ndarray_methods.py
+++ b/torch_np/tests/test_ndarray_methods.py
@@ -88,9 +88,9 @@ class TestTranspose:
         a = np.array([[1, 2], [3, 4]])
         assert_equal(a.transpose(), [[1, 3], [2, 4]])
         assert_equal(a.transpose(None), [[1, 3], [2, 4]])
-        assert_raises(ValueError, lambda: a.transpose(0))
-        assert_raises(ValueError, lambda: a.transpose(0, 0))
-        assert_raises(ValueError, lambda: a.transpose(0, 1, 2))
+        assert_raises((RuntimeError, ValueError), lambda: a.transpose(0))
+        assert_raises((RuntimeError, ValueError), lambda: a.transpose(0, 0))
+        assert_raises((RuntimeError, ValueError), lambda: a.transpose(0, 1, 2))
 
         assert a.transpose().tensor._base is a.tensor
 


### PR DESCRIPTION
- Give up trying to imitate the NumPy exceptions altogether
- Remove duplicated round, real imag
- Remove the implementation of nanmean, as it had a number of issues. If we implement masked reducitons, we should probably do them all in one go, reusing the aux functions we used for reductions.
- Minor cosmetic changes