### PR TITLE
add wrappers for np.fft

### DIFF
--- a/torch_np/__init__.py
+++ b/torch_np/__init__.py
@@ -1,4 +1,4 @@
-from . import linalg, random, fft
+from . import fft, linalg, random
 from ._dtypes import *
 from ._funcs import *
 from ._getlimits import errstate, finfo, iinfo

--- a/torch_np/__init__.py
+++ b/torch_np/__init__.py
@@ -1,4 +1,4 @@
-from . import fft, linalg, random
+from . import linalg, random, fft
 from ._dtypes import *
 from ._funcs import *
 from ._getlimits import errstate, finfo, iinfo

--- a/torch_np/fft.py
+++ b/torch_np/fft.py
@@ -1,31 +1,101 @@
-def fft():
-    raise NotImplementedError
+from __future__ import annotations
+
+import functools
+import torch
+
+from ._normalizations import ArrayLike, normalizer
+from . import _util
 
 
-def ifft():
-    raise NotImplementedError
+def upcast(func):
+    """NumPy fft casts inputs to 64 bit and *returns 64-bit results*."""
+    @functools.wraps(func)
+    def wrapped(tensor, *args, **kwds):
+        target_dtype = torch.complex128 if tensor.is_complex() else torch.float64
+        tensor = _util.cast_if_needed(tensor, target_dtype)
+        return func(tensor, *args, **kwds)
+    return wrapped
 
 
-def fftn():
-    raise NotImplementedError
+@normalizer
+@upcast
+def fft(a: ArrayLike, n=None, axis=-1, norm=None):
+    return torch.fft.fft(a, n, dim=axis, norm=norm)
 
 
-def ifftn():
-    raise NotImplementedError
+@normalizer
+@upcast
+def ifft(a: ArrayLike, n=None, axis=-1, norm=None):
+    return torch.fft.ifft(a, n, dim=axis, norm=norm)
 
 
-def rfftn():
-    raise NotImplementedError
+@normalizer
+@upcast
+def rfft(a: ArrayLike, n=None, axis=-1, norm=None):
+    return torch.fft.rfft(a, n, dim=axis, norm=norm)
 
 
-def irfftn():
-    raise NotImplementedError
+@normalizer
+@upcast
+def irfft(a: ArrayLike, n=None, axis=-1, norm=None):
+    return torch.fft.irfft(a, n, dim=axis, norm=norm)
 
 
-def fft2():
-    raise NotImplementedError
+@normalizer
+@upcast
+def fftn(a: ArrayLike, s=None, axes=None, norm=None):
+    return torch.fft.fftn(a, s, dim=axes, norm=norm)
 
 
-def ifft2():
-    raise NotImplementedError
+@normalizer
+@upcast
+def ifftn(a: ArrayLike, s=None, axes=None, norm=None):
+    return torch.fft.ifftn(a, s, dim=axes, norm=norm)
+
+
+@normalizer
+@upcast
+def rfftn(a: ArrayLike, s=None, axes=None, norm=None):
+    return torch.fft.rfftn(a, s, dim=axes, norm=norm)
+
+
+@normalizer
+@upcast
+def irfftn(a: ArrayLike, s=None, axes=None, norm=None):
+    return torch.fft.irfftn(a, s, dim=axes, norm=norm)
+
+
+@normalizer
+@upcast
+def fft2(a: ArrayLike, s=None, axes=(-2, -1), norm=None):
+    return torch.fft.fft2(a, s, dim=axes, norm=norm)
+
+@normalizer
+@upcast
+def ifft2(a: ArrayLike, s=None, axes=(-2, -1), norm=None):
+    return torch.fft.ifft2(a, s, dim=axes, norm=norm)
+
+
+@normalizer
+@upcast
+def rfft2(a: ArrayLike, s=None, axes=(-2, -1), norm=None):
+    return torch.fft.rfft2(a, s, dim=axes, norm=norm)
+
+
+@normalizer
+@upcast
+def irfft2(a: ArrayLike, s=None, axes=(-2, -1), norm=None):
+    return torch.fft.irfft2(a, s, dim=axes, norm=norm)
+
+
+@normalizer
+@upcast
+def hfft(a: ArrayLike, n=None, axis=-1, norm=None):
+    return torch.fft.hfft(a, n, dim=axis, norm=norm)
+
+@normalizer
+@upcast
+def ihfft(a: ArrayLike, n=None, axis=-1, norm=None):
+    return torch.fft.ihfft(a, n, dim=axis, norm=norm)
+
 

--- a/torch_np/fft.py
+++ b/torch_np/fft.py
@@ -28,3 +28,4 @@ def fft2():
 
 def ifft2():
     raise NotImplementedError
+

--- a/torch_np/fft.py
+++ b/torch_np/fft.py
@@ -106,3 +106,23 @@ def hfft(a: ArrayLike, n=None, axis=-1, norm=None):
 @upcast
 def ihfft(a: ArrayLike, n=None, axis=-1, norm=None):
     return torch.fft.ihfft(a, n, dim=axis, norm=norm)
+
+
+@normalizer
+def fftfreq(n, d=1.0):
+    return torch.fft.fftfreq(n, d)
+
+
+@normalizer
+def rfftfreq(n, d=1.0):
+    return torch.fft.rfftfreq(n, d)
+
+
+@normalizer
+def fftshift(x: ArrayLike, axes=None):
+    return torch.fft.fftshift(x, axes)
+
+
+@normalizer
+def ifftshift(x: ArrayLike, axes=None):
+    return torch.fft.ifftshift(x, axes)

--- a/torch_np/fft.py
+++ b/torch_np/fft.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
 import functools
+
 import torch
 
+from . import _dtypes_impl, _util
 from ._normalizations import ArrayLike, normalizer
-from . import _util
 
 
 def upcast(func):
     """NumPy fft casts inputs to 64 bit and *returns 64-bit results*."""
+
     @functools.wraps(func)
     def wrapped(tensor, *args, **kwds):
-        target_dtype = torch.complex128 if tensor.is_complex() else torch.float64
+        target_dtype = (
+            _dtypes_impl.default_dtypes.complex_dtype
+            if tensor.is_complex()
+            else _dtypes_impl.default_dtypes.float_dtype
+        )
         tensor = _util.cast_if_needed(tensor, target_dtype)
         return func(tensor, *args, **kwds)
+
     return wrapped
 
 
@@ -70,6 +77,7 @@ def irfftn(a: ArrayLike, s=None, axes=None, norm=None):
 def fft2(a: ArrayLike, s=None, axes=(-2, -1), norm=None):
     return torch.fft.fft2(a, s, dim=axes, norm=norm)
 
+
 @normalizer
 @upcast
 def ifft2(a: ArrayLike, s=None, axes=(-2, -1), norm=None):
@@ -93,9 +101,8 @@ def irfft2(a: ArrayLike, s=None, axes=(-2, -1), norm=None):
 def hfft(a: ArrayLike, n=None, axis=-1, norm=None):
     return torch.fft.hfft(a, n, dim=axis, norm=norm)
 
+
 @normalizer
 @upcast
 def ihfft(a: ArrayLike, n=None, axis=-1, norm=None):
     return torch.fft.ihfft(a, n, dim=axis, norm=norm)
-
-

--- a/torch_np/tests/numpy_tests/fft/test_helper.py
+++ b/torch_np/tests/numpy_tests/fft/test_helper.py
@@ -7,9 +7,7 @@ import torch_np as np
 from torch_np.testing import assert_array_almost_equal
 from torch_np import fft, pi
 
-import pytest
 
-@pytest.mark.xfail(reason="TODO")
 class TestFFTShift:
 
     def test_definition(self):
@@ -135,7 +133,6 @@ class TestFFTShift:
                                               original_ifftshift(inp, axes_keyword))
 
 
-@pytest.mark.xfail(reason="TODO")
 class TestFFTFreq:
 
     def test_definition(self):
@@ -147,7 +144,6 @@ class TestFFTFreq:
         assert_array_almost_equal(10*pi*fft.fftfreq(10, pi), x)
 
 
-@pytest.mark.xfail(reason="TODO")
 class TestRFFTFreq:
 
     def test_definition(self):
@@ -159,7 +155,6 @@ class TestRFFTFreq:
         assert_array_almost_equal(10*pi*fft.rfftfreq(10, pi), x)
 
 
-@pytest.mark.xfail(reason="TODO")
 class TestIRFFTN:
 
     def test_not_last_axis_success(self):

--- a/torch_np/tests/numpy_tests/fft/test_helper.py
+++ b/torch_np/tests/numpy_tests/fft/test_helper.py
@@ -85,7 +85,7 @@ class TestFFTShift:
 
     def test_equal_to_original(self):
         """ Test that the new (>=v1.15) implementation (see #10073) is equal to the original (<=v1.14) """
-        from numpy.core import asarray, concatenate, arange, take
+        from torch_np import asarray, concatenate, arange, take
 
         def original_fftshift(x, axes=None):
             """ How fftshift was implemented in v1.14"""


### PR DESCRIPTION
Is mostly straightforward, as pytorch API is nearly identical indeed. The main difference seems to be that  `numpy.fft` returns 64-bit transforms for all input dtypes. We now have `set_default_dtype` though, so we probably want fft routines to react to it: 

```
>>> a = np.arange(5, dtype=np.float32)
>>> np.fft.fft(a).dtype == np.complex128            # this is the (numpy) way
True
>>> np.set_default_dtype("pytorch")
>>> np.fft.fft(a).dtype == np.complex64
```