### PR TITLE
Tests for converting NumPy dtypes to their equivalent

### DIFF
--- a/torch_np/tests/test_dtype.py
+++ b/torch_np/tests/test_dtype.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+import torch_np as tnp
+
+dtype_names = [
+    "bool_",
+    *[f"int{w}" for w in [8, 16, 32, 64]],
+    "uint8",
+    *[f"float{w}" for w in [16, 32, 64]],
+    *[f"complex{w}" for w in [64, 128]],
+]
+np_dtype_params = []
+np_dtype_params.append(pytest.param("bool", "bool", id="'bool'"))
+np_dtype_params.append(
+    pytest.param(
+        "bool",
+        np.dtype("bool"),
+        id=f"np.dtype('bool')",
+        marks=pytest.mark.xfail(reason="XXX: np.dtype() objects not supported"),
+    )
+)
+for name in dtype_names:
+    np_dtype_params.append(pytest.param(name, name, id=repr(name)))
+    np_dtype_params.append(
+        pytest.param(
+            name,
+            getattr(np, name),
+            id=f"np.{name}",
+            marks=pytest.mark.xfail(reason="XXX: namespaced dtypes not supported"),
+        )
+    )
+    np_dtype_params.append(
+        pytest.param(
+            name,
+            np.dtype(name),
+            id=f"np.dtype({name!r})",
+            marks=pytest.mark.xfail(reason="XXX: np.dtype() objects not supported"),
+        )
+    )
+
+
+@pytest.mark.parametrize("name, np_dtype", np_dtype_params)
+def test_convert_np_dtypes(name, np_dtype):
+    tnp_dtype = tnp.dtype(np_dtype)
+    if name == "bool_":
+        assert tnp_dtype == tnp.bool_
+    elif tnp_dtype.name == "bool_":
+        assert name.startswith("bool")
+    else:
+        assert tnp_dtype.name == name

--- a/torch_np/tests/test_xps.py
+++ b/torch_np/tests/test_xps.py
@@ -144,3 +144,13 @@ def test_put(np_x, data):
     note(f"(after put) {tnp_x=}")
 
     assert_array_equal(tnp_x, tnp.asarray(np_x).astype(tnp_x.dtype))
+
+
+@pytest.mark.xfail(reason="XXX: support converting namespaced dtypes")
+@given(a=nps.arrays(dtype=nps.scalar_dtypes(), shape=nps.array_shapes()))
+def test_asarray_np_arrays(a):
+    x = tnp.asarray(a)
+    if a.dtype == np.bool_:
+        assert x.dtype == tnp.bool
+    else:
+        assert x.dtype.name == a.dtype.name


### PR DESCRIPTION
Starts from https://github.com/Quansight-Labs/numpy_pytorch_interop/pull/116 as that contains a few useful tidbits.

@ev-br see `test_dtype.py` for the failing tests I wrote for converting NumPy dtypes (and thus arrays) to the equivalent interop dtypes. Currently its a mixed bag on what gets converted correctly

```
'bool'                    PASSED
np.dtype('bool')          FAILED
'bool_'                   FAILED
np.bool_                  FAILED
np.dtype('bool_')         FAILED
'int8'                    PASSED
np.int8                   FAILED
np.dtype('int8')          PASSED
'int16'                   PASSED
np.int16                  FAILED
np.dtype('int16')         PASSED
'int32'                   PASSED
np.int32                  FAILED
np.dtype('int32')         PASSED
'int64'                   PASSED
np.int64                  FAILED
np.dtype('int64')         PASSED
'uint8'                   PASSED
np.uint8                  FAILED
np.dtype('uint8')         PASSED
'float16'                 PASSED
np.float16                FAILED
np.dtype('float16')       PASSED
'float32'                 PASSED
np.float32                FAILED
np.dtype('float32')       PASSED
'float64'                 PASSED
np.float64                FAILED
np.dtype('float64')       PASSED
'complex64'               PASSED
np.complex64              FAILED
np.dtype('complex64')     PASSED
'complex128'              PASSED
np.complex128             FAILED
np.dtype('complex128')    PASSED
```

I think the solution is pretty simple—we make sure to try using the `str()` of dtypes as a fallback (special casing `"bool_"` as `"bool"`) before raising an error.

Not a priority, just to say I think fixing this is very useful for "comparison testing" between libraries that consume NumPy-proper arrays (including NumPy) and this interop library. See `test_put` as an example of how powerful comparison testing can be with relatively little work.