### PR TITLE
Clean-up reductions

### DIFF
--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -1539,7 +1539,7 @@ def i0(x: ArrayLike):
 
 def isscalar(a):
     # We need to use normalize_array_like, but we don't want to export it in funcs.py
-    from _normalizations import normalize_array_like
+    from ._normalizations import normalize_array_like
 
     try:
         t = normalize_array_like(a)

--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -14,12 +14,8 @@ from typing import Optional, Sequence
 
 import torch
 
-from . import _dtypes_impl
-from . import _reductions as _impl
-from . import _util
-
-# these imports are for einsum only
-from ._normalizations import (  # isort: skip
+from . import _dtypes_impl, _util
+from ._normalizations import (
     ArrayLike,
     AxisLike,
     CastingModes,
@@ -27,12 +23,10 @@ from ._normalizations import (  # isort: skip
     NDArray,
     NotImplementedType,
     OutArray,
-    maybe_copy_to,
-    normalize_array_like,
-    normalize_casting,
-    normalize_dtype,
-    wrap_tensors,
 )
+
+# Export all the functios from _reductions, which will be picked up at funcs.py
+from ._reductions import *
 
 # ###### array creation routines
 
@@ -1223,8 +1217,16 @@ def outer(a: ArrayLike, b: ArrayLike, out: Optional[OutArray] = None):
 
 def einsum(*operands, out=None, dtype=None, order="K", casting="safe", optimize=False):
     # Have to manually normalize *operands and **kwargs, following the NumPy signature
-
+    # We have a local import to avoid poluting the global space, as it will be then
+    # exported in funcs.py
     from ._ndarray import ndarray
+    from ._normalizations import (
+        maybe_copy_to,
+        normalize_array_like,
+        normalize_casting,
+        normalize_dtype,
+        wrap_tensors,
+    )
 
     dtype = normalize_dtype(dtype)
     casting = normalize_casting(casting)
@@ -1415,279 +1417,6 @@ def ravel(a: ArrayLike, order: NotImplementedType = "C"):
     return torch.flatten(a)
 
 
-# ### reductions ###
-
-
-def sum(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    dtype: Optional[DTypeLike] = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-    initial: NotImplementedType = None,
-    where: NotImplementedType = None,
-):
-    result = _impl.sum(
-        a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
-    )
-    return result
-
-
-def prod(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    dtype: Optional[DTypeLike] = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-    initial: NotImplementedType = None,
-    where: NotImplementedType = None,
-):
-    result = _impl.prod(
-        a, axis=axis, dtype=dtype, initial=initial, where=where, keepdims=keepdims
-    )
-    return result
-
-
-product = prod
-
-
-def mean(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    dtype: Optional[DTypeLike] = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-    *,
-    where: NotImplementedType = None,
-):
-    result = _impl.mean(a, axis=axis, dtype=dtype, where=None, keepdims=keepdims)
-    return result
-
-
-def var(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    dtype: Optional[DTypeLike] = None,
-    out: Optional[OutArray] = None,
-    ddof=0,
-    keepdims=None,
-    *,
-    where: NotImplementedType = None,
-):
-    result = _impl.var(
-        a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
-    )
-    return result
-
-
-def std(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    dtype: Optional[DTypeLike] = None,
-    out: Optional[OutArray] = None,
-    ddof=0,
-    keepdims=None,
-    *,
-    where: NotImplementedType = None,
-):
-    result = _impl.std(
-        a, axis=axis, dtype=dtype, ddof=ddof, where=where, keepdims=keepdims
-    )
-    return result
-
-
-def argmin(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    *,
-    keepdims=None,
-):
-    result = _impl.argmin(a, axis=axis, keepdims=keepdims)
-    return result
-
-
-def argmax(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    *,
-    keepdims=None,
-):
-    result = _impl.argmax(a, axis=axis, keepdims=keepdims)
-    return result
-
-
-def amax(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-    initial: NotImplementedType = None,
-    where: NotImplementedType = None,
-):
-    result = _impl.max(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
-    return result
-
-
-max = amax
-
-
-def amin(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-    initial: NotImplementedType = None,
-    where: NotImplementedType = None,
-):
-    result = _impl.min(a, axis=axis, initial=initial, where=where, keepdims=keepdims)
-    return result
-
-
-min = amin
-
-
-def ptp(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-):
-    result = _impl.ptp(a, axis=axis, keepdims=keepdims)
-    return result
-
-
-def all(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-    *,
-    where: NotImplementedType = None,
-):
-    result = _impl.all(a, axis=axis, where=where, keepdims=keepdims)
-    return result
-
-
-def any(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    keepdims=None,
-    *,
-    where: NotImplementedType = None,
-):
-    result = _impl.any(a, axis=axis, where=where, keepdims=keepdims)
-    return result
-
-
-def count_nonzero(a: ArrayLike, axis: AxisLike = None, *, keepdims=False):
-    result = _impl.count_nonzero(a, axis=axis, keepdims=keepdims)
-    return result
-
-
-def cumsum(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    dtype: Optional[DTypeLike] = None,
-    out: Optional[OutArray] = None,
-):
-    result = _impl.cumsum(a, axis=axis, dtype=dtype)
-    return result
-
-
-def cumprod(
-    a: ArrayLike,
-    axis: AxisLike = None,
-    dtype: Optional[DTypeLike] = None,
-    out: Optional[OutArray] = None,
-):
-    result = _impl.cumprod(a, axis=axis, dtype=dtype)
-    return result
-
-
-cumproduct = cumprod
-
-
-def quantile(
-    a: ArrayLike,
-    q: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    overwrite_input=False,
-    method="linear",
-    keepdims=False,
-    *,
-    interpolation: NotImplementedType = None,
-):
-    result = _impl.quantile(
-        a,
-        q,
-        axis,
-        overwrite_input=overwrite_input,
-        method=method,
-        keepdims=keepdims,
-        interpolation=interpolation,
-    )
-    return result
-
-
-def percentile(
-    a: ArrayLike,
-    q: ArrayLike,
-    axis: AxisLike = None,
-    out: Optional[OutArray] = None,
-    overwrite_input=False,
-    method="linear",
-    keepdims=False,
-    *,
-    interpolation: NotImplementedType = None,
-):
-    result = _impl.percentile(
-        a,
-        q,
-        axis,
-        overwrite_input=overwrite_input,
-        method=method,
-        keepdims=keepdims,
-        interpolation=interpolation,
-    )
-    return result
-
-
-def median(
-    a: ArrayLike,
-    axis=None,
-    out: Optional[OutArray] = None,
-    overwrite_input=False,
-    keepdims=False,
-):
-    return quantile(
-        a,
-        torch.as_tensor(0.5),
-        axis=axis,
-        overwrite_input=overwrite_input,
-        out=out,
-        keepdims=keepdims,
-    )
-
-
-def average(
-    a: ArrayLike,
-    axis=None,
-    weights: ArrayLike = None,
-    returned=False,
-    *,
-    keepdims=None,
-):
-    result, wsum = _impl.average(a, axis, weights, returned=returned, keepdims=keepdims)
-    if returned:
-        return result, wsum
-    else:
-        return result
-
-
 def diff(
     a: ArrayLike,
     n=1,
@@ -1809,6 +1538,9 @@ def i0(x: ArrayLike):
 
 
 def isscalar(a):
+    # We need to use normalize_array_like, but we don't want to export it in funcs.py
+    from _normalizations import normalize_array_like
+
     try:
         t = normalize_array_like(a)
         return t.numel() == 1

--- a/torch_np/_reductions.py
+++ b/torch_np/_reductions.py
@@ -3,45 +3,44 @@ in the 'public' layer.
 
 Anything here only deals with torch objects, e.g. "dtype" is a torch.dtype instance etc
 """
+from __future__ import annotations
 
 import functools
+from typing import Optional
 
 import torch
 
 from . import _dtypes_impl, _util
+from ._normalizations import (
+    ArrayLike,
+    AxisLike,
+    DTypeLike,
+    KeepDims,
+    NotImplementedType,
+    OutArray,
+)
 
 
-def deco_axis_expand(func):
-    """Generically handle axis arguments in reductions."""
+def _deco_axis_expand(func):
+    """
+    Generically handle axis arguments in reductions.
+    axis is *always* the 2nd arg in the funciton so no need to have a look at its signature
+    """
 
     @functools.wraps(func)
-    def wrapped(tensor, axis=None, *args, **kwds):
+    def wrapped(a, axis=None, *args, **kwds):
 
         if axis is not None:
-            axis = _util.normalize_axis_tuple(axis, tensor.ndim)
+            axis = _util.normalize_axis_tuple(axis, a.ndim)
 
         if axis == ():
-            # NumPy does essentially an identity operation:
-            # >>> np.sum(np.ones(2), axis=())
-            # array([1., 1.])
             # So we insert a length-one axis and run the reduction along it.
-            newshape = _util.expand_shape(tensor.shape, axis=0)
-            tensor = tensor.reshape(newshape)
+            # We cannot return a.clone() as this would sidestep the checks inside the function
+            newshape = _util.expand_shape(a.shape, axis=0)
+            a = a.reshape(newshape)
             axis = (0,)
 
-        result = func(tensor, axis, *args, **kwds)
-        return result
-
-    return wrapped
-
-
-def emulate_keepdims(func):
-    @functools.wraps(func)
-    def wrapped(tensor, axis=None, keepdims=None, *args, **kwds):
-        result = func(tensor, axis, *args, **kwds)
-        if keepdims:
-            result = _util.apply_keepdims(result, axis, tensor.ndim)
-        return result
+        return func(a, axis, *args, **kwds)
 
     return wrapped
 
@@ -60,106 +59,173 @@ def _atleast_float(dtype, other_dtype):
     return dtype
 
 
-@emulate_keepdims
-@deco_axis_expand
-def count_nonzero(a, axis=None):
+@_deco_axis_expand
+def count_nonzero(a: ArrayLike, axis: AxisLike = None, *, keepdims: KeepDims = False):
     return a.count_nonzero(axis)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def argmax(tensor, axis=None):
+@_deco_axis_expand
+def argmax(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    *,
+    keepdims: KeepDims = False,
+):
     axis = _util.allow_only_single_axis(axis)
 
-    if tensor.dtype == torch.bool:
+    if a.dtype == torch.bool:
         # RuntimeError: "argmax_cpu" not implemented for 'Bool'
-        tensor = tensor.to(torch.uint8)
+        a = a.to(torch.uint8)
 
-    return torch.argmax(tensor, axis)
+    return torch.argmax(a, axis)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def argmin(tensor, axis=None):
+@_deco_axis_expand
+def argmin(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    *,
+    keepdims: KeepDims = False,
+):
     axis = _util.allow_only_single_axis(axis)
 
-    if tensor.dtype == torch.bool:
+    if a.dtype == torch.bool:
         # RuntimeError: "argmin_cpu" not implemented for 'Bool'
-        tensor = tensor.to(torch.uint8)
+        a = a.to(torch.uint8)
 
-    return torch.argmin(tensor, axis)
+    return torch.argmin(a, axis)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def any(tensor, axis=None, *, where=None):
+@_deco_axis_expand
+def any(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+    *,
+    where: NotImplementedType = None,
+):
     axis = _util.allow_only_single_axis(axis)
     axis_kw = {} if axis is None else {"dim": axis}
-    return torch.any(tensor, **axis_kw)
+    return torch.any(a, **axis_kw)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def all(tensor, axis=None, *, where=None):
+@_deco_axis_expand
+def all(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+    *,
+    where: NotImplementedType = None,
+):
     axis = _util.allow_only_single_axis(axis)
     axis_kw = {} if axis is None else {"dim": axis}
-    return torch.all(tensor, **axis_kw)
+    return torch.all(a, **axis_kw)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def max(tensor, axis=None, initial=None, where=None):
-    return tensor.amax(axis)
+@_deco_axis_expand
+def amax(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
+):
+    return a.amax(axis)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def min(tensor, axis=None, initial=None, where=None):
-    return tensor.amin(axis)
+max = amax
 
 
-@emulate_keepdims
-@deco_axis_expand
-def ptp(tensor, axis=None):
-    return tensor.amax(axis) - tensor.amin(axis)
+@_deco_axis_expand
+def amin(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
+):
+    return a.amin(axis)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def sum(tensor, axis=None, dtype=None, initial=None, where=None):
+min = amin
+
+
+@_deco_axis_expand
+def ptp(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+):
+    return a.amax(axis) - a.amin(axis)
+
+
+@_deco_axis_expand
+def sum(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    dtype: Optional[DTypeLike] = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
+):
     assert dtype is None or isinstance(dtype, torch.dtype)
 
     if dtype == torch.bool:
         dtype = _dtypes_impl.default_dtypes.int_dtype
 
     if axis is None:
-        result = tensor.sum(dtype=dtype)
+        result = a.sum(dtype=dtype)
     else:
-        result = tensor.sum(dtype=dtype, dim=axis)
+        result = a.sum(dtype=dtype, dim=axis)
 
     return result
 
 
-@emulate_keepdims
-@deco_axis_expand
-def prod(tensor, axis=None, dtype=None, initial=None, where=None):
+@_deco_axis_expand
+def prod(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    dtype: Optional[DTypeLike] = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+    initial: NotImplementedType = None,
+    where: NotImplementedType = None,
+):
     axis = _util.allow_only_single_axis(axis)
 
     if dtype == torch.bool:
         dtype = _dtypes_impl.default_dtypes.int_dtype
 
     if axis is None:
-        result = tensor.prod(dtype=dtype)
+        result = a.prod(dtype=dtype)
     else:
-        result = tensor.prod(dtype=dtype, dim=axis)
+        result = a.prod(dtype=dtype, dim=axis)
 
     return result
 
 
-@emulate_keepdims
-@deco_axis_expand
-def mean(tensor, axis=None, dtype=None, *, where=None):
-    dtype = _atleast_float(dtype, tensor.dtype)
+product = prod
+
+
+@_deco_axis_expand
+def mean(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    dtype: Optional[DTypeLike] = None,
+    out: Optional[OutArray] = None,
+    keepdims: KeepDims = False,
+    *,
+    where: NotImplementedType = None,
+):
+    dtype = _atleast_float(dtype, a.dtype)
 
     is_half = dtype == torch.float16
     if is_half:
@@ -167,9 +233,9 @@ def mean(tensor, axis=None, dtype=None, *, where=None):
         dtype = torch.float32
 
     if axis is None:
-        result = tensor.mean(dtype=dtype)
+        result = a.mean(dtype=dtype)
     else:
-        result = tensor.mean(dtype=dtype, dim=axis)
+        result = a.mean(dtype=dtype, dim=axis)
 
     if is_half:
         result = result.to(torch.float16)
@@ -177,19 +243,35 @@ def mean(tensor, axis=None, dtype=None, *, where=None):
     return result
 
 
-@emulate_keepdims
-@deco_axis_expand
-def std(tensor, axis=None, dtype=None, ddof=0, *, where=None):
-    dtype = _atleast_float(dtype, tensor.dtype)
-    tensor = _util.cast_if_needed(tensor, dtype)
+@_deco_axis_expand
+def std(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    dtype: Optional[DTypeLike] = None,
+    out: Optional[OutArray] = None,
+    ddof=0,
+    keepdims: KeepDims = False,
+    *,
+    where: NotImplementedType = None,
+):
+    dtype = _atleast_float(dtype, a.dtype)
+    tensor = _util.cast_if_needed(a, dtype)
     return tensor.std(dim=axis, correction=ddof)
 
 
-@emulate_keepdims
-@deco_axis_expand
-def var(tensor, axis=None, dtype=None, ddof=0, *, where=None):
-    dtype = _atleast_float(dtype, tensor.dtype)
-    tensor = _util.cast_if_needed(tensor, dtype)
+@_deco_axis_expand
+def var(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    dtype: Optional[DTypeLike] = None,
+    out: Optional[OutArray] = None,
+    ddof=0,
+    keepdims: KeepDims = False,
+    *,
+    where: NotImplementedType = None,
+):
+    dtype = _atleast_float(dtype, a.dtype)
+    tensor = _util.cast_if_needed(a, dtype)
     return tensor.var(dim=axis, correction=ddof)
 
 
@@ -198,48 +280,75 @@ def var(tensor, axis=None, dtype=None, ddof=0, *, where=None):
 #   2. axis=None flattens
 
 
-def cumprod(tensor, axis, dtype=None):
+def cumsum(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    dtype: Optional[DTypeLike] = None,
+    out: Optional[OutArray] = None,
+):
     if dtype == torch.bool:
         dtype = _dtypes_impl.default_dtypes.int_dtype
     if dtype is None:
-        dtype = tensor.dtype
+        dtype = a.dtype
 
-    (tensor,), axis = _util.axis_none_flatten(tensor, axis=axis)
-    axis = _util.normalize_axis_index(axis, tensor.ndim)
+    (a,), axis = _util.axis_none_flatten(a, axis=axis)
+    axis = _util.normalize_axis_index(axis, a.ndim)
 
-    return tensor.cumprod(axis=axis, dtype=dtype)
+    return a.cumsum(axis=axis, dtype=dtype)
 
 
-def cumsum(tensor, axis, dtype=None):
+def cumprod(
+    a: ArrayLike,
+    axis: AxisLike = None,
+    dtype: Optional[DTypeLike] = None,
+    out: Optional[OutArray] = None,
+):
     if dtype == torch.bool:
         dtype = _dtypes_impl.default_dtypes.int_dtype
     if dtype is None:
-        dtype = tensor.dtype
+        dtype = a.dtype
 
-    (tensor,), axis = _util.axis_none_flatten(tensor, axis=axis)
-    axis = _util.normalize_axis_index(axis, tensor.ndim)
+    (a,), axis = _util.axis_none_flatten(a, axis=axis)
+    axis = _util.normalize_axis_index(axis, a.ndim)
 
-    return tensor.cumsum(axis=axis, dtype=dtype)
+    return a.cumprod(axis=axis, dtype=dtype)
 
 
-def average(a, axis, weights, returned=False, keepdims=False):
+cumproduct = cumprod
+
+
+@_deco_axis_expand
+def average(
+    a: ArrayLike,
+    axis=None,
+    weights: ArrayLike = None,
+    returned=False,
+    *,
+    keepdims=False,
+):
     if weights is None:
-        result, wsum = average_noweights(a, axis, keepdims=keepdims)
+        result, wsum = _average_noweights(a, axis)
     else:
-        result, wsum = average_weights(a, axis, weights, keepdims=keepdims)
+        result, wsum = _average_weights(a, axis, weights)
 
-    if returned and wsum.shape != result.shape:
-        wsum = torch.broadcast_to(wsum, result.shape).clone()
-    return result, wsum
+    if keepdims:
+        result = _util.apply_keepdims(result, axis, a.ndim)
+
+    if returned:
+        if wsum.shape != result.shape:
+            wsum = torch.broadcast_to(wsum, result.shape).clone()
+        return result, wsum
+    else:
+        return result
 
 
-def average_noweights(a, axis, keepdims=False):
-    result = mean(a, axis=axis, keepdims=keepdims)
+def _average_noweights(a, axis):
+    result = mean(a, axis=axis)
     scl = torch.as_tensor(a.numel() / result.numel(), dtype=result.dtype)
     return result, scl
 
 
-def average_weights(a, axis, w, keepdims=False):
+def _average_weights(a, axis, w):
     if not a.dtype.is_floating_point:
         a = a.double()
 
@@ -265,21 +374,19 @@ def average_weights(a, axis, w, keepdims=False):
     denominator = w.sum(axis, dtype=result_dtype)
     result = numerator / denominator
 
-    # keepdims
-    if keepdims:
-        result = _util.apply_keepdims(result, axis, a.ndim)
-
     return result, denominator
 
 
 def quantile(
-    a,
-    q,
-    axis,
-    overwrite_input,
-    method,
-    keepdims=False,
-    interpolation=None,
+    a: ArrayLike,
+    q: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    overwrite_input=False,
+    method="linear",
+    keepdims: KeepDims = False,
+    *,
+    interpolation: NotImplementedType = None,
 ):
     if overwrite_input:
         # raise NotImplementedError("overwrite_input in quantile not implemented.")
@@ -296,8 +403,6 @@ def quantile(
     if a.dtype == torch.float16:
         a = a.to(torch.float32)
 
-    # axis=None flattens, so store the originals to reuse with keepdims=True below
-    ax, ndim = axis, a.ndim
     if axis is None:
         a = a.flatten()
         q = q.flatten()
@@ -312,24 +417,19 @@ def quantile(
 
     q = _util.cast_if_needed(q, a.dtype)
 
-    result = torch.quantile(a, q, axis=axis, interpolation=method)
-
-    # NB: not using @emulate_keepdims here because the signature is (a, q, axis, ...)
-    # while the decorator expects (a, axis, ...)
-    # this can be fixed, of course, but the cure seems worse then the desease
-    if keepdims:
-        result = _util.apply_keepdims(result, ax, ndim)
-    return result
+    return torch.quantile(a, q, axis=axis, interpolation=method)
 
 
 def percentile(
-    a,
-    q,
-    axis,
-    overwrite_input,
-    method,
-    keepdims=False,
-    interpolation=None,
+    a: ArrayLike,
+    q: ArrayLike,
+    axis: AxisLike = None,
+    out: Optional[OutArray] = None,
+    overwrite_input=False,
+    method="linear",
+    keepdims: KeepDims = False,
+    *,
+    interpolation: NotImplementedType = None,
 ):
     return quantile(
         a,
@@ -339,4 +439,21 @@ def percentile(
         method=method,
         keepdims=keepdims,
         interpolation=interpolation,
+    )
+
+
+def median(
+    a: ArrayLike,
+    axis=None,
+    out: Optional[OutArray] = None,
+    overwrite_input=False,
+    keepdims: KeepDims = False,
+):
+    return quantile(
+        a,
+        torch.as_tensor(0.5),
+        axis=axis,
+        overwrite_input=overwrite_input,
+        out=out,
+        keepdims=keepdims,
     )

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -7,7 +7,7 @@ from typing import Sequence
 import torch
 
 from . import _dtypes_impl, _util
-from ._normalizations import ArrayLike, normalizer
+from ._normalizations import ArrayLike, KeepDims, normalizer
 
 
 class LinAlgError(Exception):
@@ -47,7 +47,7 @@ def linalg_errors(func):
 @normalizer
 @linalg_errors
 def matrix_power(a: ArrayLike, n):
-    a = _atleat_float_1(a)
+    a = _atleast_float_1(a)
     return torch.linalg.matrix_power(a, n)
 
 
@@ -160,12 +160,9 @@ def matrix_rank(a: ArrayLike, tol=None, hermitian=False):
 
 @normalizer
 @linalg_errors
-def norm(x: ArrayLike, ord=None, axis=None, keepdims=False):
+def norm(x: ArrayLike, ord=None, axis=None, keepdims: KeepDims = False):
     x = _atleast_float_1(x)
-    result = torch.linalg.norm(x, ord=ord, dim=axis)
-    if keepdims:
-        result = _util.apply_keepdims(result, axis, x.ndim)
-    return result
+    return torch.linalg.norm(x, ord=ord, dim=axis)
 
 
 # ### Decompositions ###
@@ -210,10 +207,9 @@ def eig(a: ArrayLike):
     a = _atleast_float_1(a)
     w, vt = torch.linalg.eig(a)
 
-    if not a.is_complex():
-        if w.is_complex() and (w.imag == 0).all():
-            w = w.real
-            vt = vt.real
+    if not a.is_complex() and w.is_complex() and (w.imag == 0).all():
+        w = w.real
+        vt = vt.real
     return w, vt
 
 
@@ -229,9 +225,8 @@ def eigh(a: ArrayLike, UPLO="L"):
 def eigvals(a: ArrayLike):
     a = _atleast_float_1(a)
     result = torch.linalg.eigvals(a)
-    if not a.is_complex():
-        if result.is_complex() and (result.imag == 0).all():
-            result = result.real
+    if not a.is_complex() and result.is_complex() and (result.imag == 0).all():
+        result = result.real
     return result
 
 

--- a/torch_np/tests/test_basic.py
+++ b/torch_np/tests/test_basic.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 
 import numpy as _np
 import pytest
@@ -539,3 +540,16 @@ class TestDefaultDtype:
         finally:
             # restore the
             w.set_default_dtype(fp_dtype="numpy")
+
+
+class TestExport:
+    def test_exported_objects(self):
+        exported_fns = (
+            x
+            for x in dir(w)
+            if inspect.isfunction(getattr(w, x))
+            and not x.startswith("_")
+            and x != "set_default_dtype"
+        )
+        diff = set(exported_fns).difference(set(dir(_np)))
+        assert len(diff) == 0


### PR DESCRIPTION
- Avoid the repetition of the signature of reductions
- Fix keepdims. With the previous implementation it was not possible to set it as a positional arg.
- Fix some functions that were incorrectly exported in `torch_np`. Added a test for this as well.
  - To go with this, I had to move the imports back into `einsum` to avoid having an `from _normalizations import` and a `import _normalizations` right after it, as discussed.