### PR TITLE
Wrap from_dlpack and its dunders

### DIFF
--- a/torch_np/__init__.py
+++ b/torch_np/__init__.py
@@ -2,7 +2,15 @@ from . import fft, linalg, random
 from ._dtypes import *
 from ._funcs import *
 from ._getlimits import errstate, finfo, iinfo
-from ._ndarray import array, asarray, can_cast, ndarray, newaxis, result_type
+from ._ndarray import (
+    array,
+    asarray,
+    can_cast,
+    from_dlpack,
+    ndarray,
+    newaxis,
+    result_type,
+)
 from ._ufuncs import *
 from ._util import AxisError, UFuncTypeError
 

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -442,6 +442,12 @@ class ndarray:
     take = _funcs.take
     put = _funcs.put
 
+    def __dlpack__(self, *, stream=None):
+        return self.tensor.__dlpack__(stream=stream)
+
+    def __dlpack_device__(self):
+        return self.tensor.__dlpack_device__()
+
 
 # This is the ideally the only place which talks to ndarray directly.
 # The rest goes through asarray (preferred) or array.
@@ -486,6 +492,11 @@ def array(obj, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, like=N
 
 def asarray(a, dtype=None, order="K", *, like=None):
     return array(a, dtype=dtype, order=order, like=like, copy=False, ndmin=0)
+
+
+def from_dlpack(x, /):
+    t = torch.from_dlpack(x)
+    return ndarray(t)
 
 
 ###### dtype routines

--- a/torch_np/tests/numpy_tests/core/test_dlpack.py
+++ b/torch_np/tests/numpy_tests/core/test_dlpack.py
@@ -1,0 +1,125 @@
+import sys
+import pytest
+
+import torch_np as np
+from torch_np.testing import assert_array_equal
+
+IS_PYPY = False
+
+
+class TestDLPack:
+    @pytest.mark.skipif(IS_PYPY, reason="PyPy can't get refcounts.")
+    def test_dunder_dlpack_refcount(self):
+        x = np.arange(5)
+        y = x.__dlpack__()
+        assert sys.getrefcount(x) == 3
+        del y
+        assert sys.getrefcount(x) == 2
+
+    def test_dunder_dlpack_stream(self):
+        x = np.arange(5)
+        x.__dlpack__(stream=None)
+
+        with pytest.raises(RuntimeError):
+            x.__dlpack__(stream=1)
+
+    def test_strides_not_multiple_of_itemsize(self):
+        dt = np.dtype([('int', np.int32), ('char', np.int8)])
+        y = np.zeros((5,), dtype=dt)
+        z = y['int']
+
+        with pytest.raises(BufferError):
+            np.from_dlpack(z)
+
+    @pytest.mark.skipif(IS_PYPY, reason="PyPy can't get refcounts.")
+    def test_from_dlpack_refcount(self):
+        x = np.arange(5)
+        y = np.from_dlpack(x)
+        assert sys.getrefcount(x) == 3
+        del y
+        assert sys.getrefcount(x) == 2
+
+    @pytest.mark.parametrize("dtype", [
+        np.int8, np.int16, np.int32, np.int64,
+        np.uint8,
+        np.float16, np.float32, np.float64,
+        np.complex64, np.complex128
+    ])
+    def test_dtype_passthrough(self, dtype):
+        x = np.arange(5, dtype=dtype)
+        y = np.from_dlpack(x)
+
+        assert y.dtype == x.dtype
+        assert_array_equal(x, y)
+
+    def test_invalid_dtype(self):
+        x = np.asarray(np.datetime64('2021-05-27'))
+
+        with pytest.raises(BufferError):
+            np.from_dlpack(x)
+
+    def test_invalid_byte_swapping(self):
+        dt = np.dtype('=i8').newbyteorder()
+        x = np.arange(5, dtype=dt)
+
+        with pytest.raises(BufferError):
+            np.from_dlpack(x)
+
+    def test_non_contiguous(self):
+        x = np.arange(25).reshape((5, 5))
+
+        y1 = x[0]
+        assert_array_equal(y1, np.from_dlpack(y1))
+
+        y2 = x[:, 0]
+        assert_array_equal(y2, np.from_dlpack(y2))
+
+        y3 = x[1, :]
+        assert_array_equal(y3, np.from_dlpack(y3))
+
+        y4 = x[1]
+        assert_array_equal(y4, np.from_dlpack(y4))
+
+        y5 = np.diagonal(x).copy()
+        assert_array_equal(y5, np.from_dlpack(y5))
+
+    @pytest.mark.parametrize("ndim", range(33))
+    def test_higher_dims(self, ndim):
+        shape = (1,) * ndim
+        x = np.zeros(shape, dtype=np.float64)
+
+        assert shape == np.from_dlpack(x).shape
+
+    def test_dlpack_device(self):
+        x = np.arange(5)
+        assert x.__dlpack_device__() == (1, 0)
+        y = np.from_dlpack(x)
+        assert y.__dlpack_device__() == (1, 0)
+        z = y[::2]
+        assert z.__dlpack_device__() == (1, 0)
+
+    def dlpack_deleter_exception(self):
+        x = np.arange(5)
+        _ = x.__dlpack__()
+        raise RuntimeError
+
+    def test_dlpack_destructor_exception(self):
+        with pytest.raises(RuntimeError):
+            self.dlpack_deleter_exception()
+
+    def test_readonly(self):
+        x = np.arange(5)
+        x.flags.writeable = False
+        with pytest.raises(BufferError):
+            x.__dlpack__()
+
+    def test_ndim0(self):
+        x = np.array(1.0)
+        y = np.from_dlpack(x)
+        assert_array_equal(x, y)
+
+    def test_size1dims_arrays(self):
+        x = np.ndarray(dtype='f8', shape=(10, 5, 1), strides=(8, 80, 4),
+                       buffer=np.ones(1000, dtype=np.uint8), order='F')
+        y = np.from_dlpack(x)
+        assert_array_equal(x, y)


### PR DESCRIPTION
Just delegate to whatever self.tensor does under the hood.

- vendor the numpy tests suite
- remove datetimes, structured dtypes etc
- had to xfail refcounting related tests --- checked that pytorch does not pass these either.
- had to xfail a test with a non-None dlpack stream --- checked that pytorch does not raise

Also added a small test to check that tnp arrays can be created from / exported to pytorch tensors.

Poking around in ipython, it seems that `np.from_dlpack(torch.Tensor)` creates a readonly array, while the other direction it's a view. Not sure if there's something to do or if we can do anything about it really.

```
In [48]: a = np.arange(3)

In [49]: a
Out[49]: array([0, 1, 2])

In [50]: t = torch.from_dlpack(a)

In [51]: t[0] = 42

In [52]: t
Out[52]: tensor([42,  1,  2])

In [53]: a
Out[53]: array([42,  1,  2])
```