### PR TITLE
ENH: control a random stream to be from either numpy or pytorch

### DIFF
--- a/torch_np/random.py
+++ b/torch_np/random.py
@@ -30,25 +30,25 @@ __all__ = [
     "randint",
     "shuffle",
     "uniform",
-    "RANDOM_STREAM",
+    "USE_NUMPY_RANDOM",
 ]
 
 
-RANDOM_STREAM = "pytorch"
+USE_NUMPY_RANDOM = False
 
 
 def deco_stream(func):
     @functools.wraps(func)
     def inner(*args, **kwds):
-        if RANDOM_STREAM == "pytorch":
+        if USE_NUMPY_RANDOM is False:
             return func(*args, **kwds)
-        elif RANDOM_STREAM == "numpy":
+        elif USE_NUMPY_RANDOM is True:
             from numpy import random as nr
 
             f = getattr(nr, func.__name__)
             return f(*args, **kwds)
         else:
-            raise ValueError(f"RANDOM_STREAM={RANDOM_STREAM} not understood.")
+            raise ValueError(f"USE_NUMPY_RANDOM={USE_NUMPY_RANDOM} not understood.")
 
     return inner
 

--- a/torch_np/tests/test_random.py
+++ b/torch_np/tests/test_random.py
@@ -16,7 +16,7 @@ def test_shuffle():
 
 
 def test_numpy_global():
-    tnp.random.RANDOM_STREAM = "numpy"
+    tnp.random.USE_NUMPY_RANDOM = True
     tnp.random.seed(12345)
     x = tnp.random.uniform(0, 1, size=11)
 
@@ -29,7 +29,7 @@ def test_numpy_global():
     assert_equal(x, tnp.asarray(x_np))
 
     # switch to the pytorch stream, variates differ
-    tnp.random.RANDOM_STREAM = "pytorch"
+    tnp.random.USE_NUMPY_RANDOM = False
     tnp.random.seed(12345)
 
     x_1 = tnp.random.uniform(0, 1, size=11)
@@ -37,6 +37,6 @@ def test_numpy_global():
 
 
 def test_wrong_global():
-    tnp.random.RANDOM_STREAM = "oops"
+    tnp.random.USE_NUMPY_RANDOM = "oops"
     with pytest.raises(ValueError):
         tnp.random.rand()

--- a/torch_np/tests/test_random.py
+++ b/torch_np/tests/test_random.py
@@ -1,0 +1,42 @@
+"""Light smoke test switching between numpy to pytorch random streams.
+"""
+import pytest
+
+import torch_np as tnp
+from torch_np.testing import assert_equal
+
+
+def test_uniform():
+    r = tnp.random.uniform(0, 1, size=10)
+
+
+def test_shuffle():
+    x = tnp.arange(10)
+    tnp.random.shuffle(x)
+
+
+def test_numpy_global():
+    tnp.random.RANDOM_STREAM = "numpy"
+    tnp.random.seed(12345)
+    x = tnp.random.uniform(0, 1, size=11)
+
+    # check that the stream is identical to numpy's
+    import numpy as _np
+
+    _np.random.seed(12345)
+    x_np = _np.random.uniform(0, 1, size=11)
+
+    assert_equal(x, tnp.asarray(x_np))
+
+    # switch to the pytorch stream, variates differ
+    tnp.random.RANDOM_STREAM = "pytorch"
+    tnp.random.seed(12345)
+
+    x_1 = tnp.random.uniform(0, 1, size=11)
+    assert not (x_1 == x).all()
+
+
+def test_wrong_global():
+    tnp.random.RANDOM_STREAM = "oops"
+    with pytest.raises(ValueError):
+        tnp.random.rand()

--- a/torch_np/tests/test_random.py
+++ b/torch_np/tests/test_random.py
@@ -37,6 +37,12 @@ def test_numpy_global():
 
 
 def test_wrong_global():
-    tnp.random.USE_NUMPY_RANDOM = "oops"
-    with pytest.raises(ValueError):
-        tnp.random.rand()
+    try:
+        oldstate = tnp.random.USE_NUMPY_RANDOM
+
+        tnp.random.USE_NUMPY_RANDOM = "oops"
+        with pytest.raises(ValueError):
+            tnp.random.rand()
+
+    finally:
+        tnp.random.USE_NUMPY_RANDOM = oldstate


### PR DESCRIPTION
Add a global switch to select the random stream origin: pytorch or numpy. If points to NumPy, `tnp.random.uniform` just calls `numpy.random.uniform` etc. 