### PR TITLE
MAINT: rework result_type_impl to accept *tensors, not dtypes

### DIFF
--- a/torch_np/_binary_ufuncs_impl.py
+++ b/torch_np/_binary_ufuncs_impl.py
@@ -51,7 +51,7 @@ def matmul(x, y):
     #  - RuntimeError: expected scalar type Int but found Double
     #  - RuntimeError: "addmm_impl_cpu_" not implemented for 'Bool'
     #  - RuntimeError: "addmm_impl_cpu_" not implemented for 'Half'
-    dtype = _dtypes_impl.result_type_impl((x.dtype, y.dtype))
+    dtype = _dtypes_impl.result_type_impl(x, y)
     is_bool = dtype == torch.bool
     is_half = dtype == torch.float16
 

--- a/torch_np/_dtypes.py
+++ b/torch_np/_dtypes.py
@@ -6,7 +6,7 @@ import builtins
 
 import torch
 
-from . import _dtypes_impl
+from . import _dtypes_impl, _util
 
 # more __all__ manipulations at the bottom
 __all__ = ["dtype", "DType", "typecodes", "issubdtype", "set_default_dtype"]
@@ -34,7 +34,7 @@ class generic(abc.ABC):
             tensor = value.tensor
         else:
             try:
-                tensor = torch.as_tensor(value, dtype=self.torch_dtype)
+                tensor = _util._coerce_to_tensor(value, dtype=self.torch_dtype)
             except RuntimeError as e:
                 if "Overflow" in str(e):
                     raise OverflowError(e.args)

--- a/torch_np/_dtypes_impl.py
+++ b/torch_np/_dtypes_impl.py
@@ -39,13 +39,13 @@ def can_cast_impl(from_torch_dtype, to_torch_dtype, casting):
     return _cd._can_cast_dict[casting][from_torch_dtype][to_torch_dtype]
 
 
-def result_type_impl(dtypes):
+def result_type_impl(*tensors):
     # NB: torch dtypes here
-    dtyp = dtypes[0]
-    if len(dtypes) == 1:
+    dtyp = tensors[0].dtype
+    if len(tensors) == 1:
         return dtyp
 
-    for curr in dtypes[1:]:
-        dtyp = _cd._result_type_dict[dtyp][curr]
+    for curr in tensors[1:]:
+        dtyp = _cd._result_type_dict[dtyp][curr.dtype]
 
     return dtyp

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -518,11 +518,14 @@ def can_cast(from_, to, casting="safe"):
 
 
 def result_type(*arrays_and_dtypes):
-    dtypes = []
-
+    tensors = []
     for entry in arrays_and_dtypes:
-        dty = _extract_dtype(entry)
-        dtypes.append(dty.torch_dtype)
+        try:
+            t = asarray(entry).tensor
+        except ((RuntimeError, ValueError, TypeError)):
+            dty = _dtypes.dtype(entry)
+            t = torch.empty(1, dtype=dty.torch_dtype)
+        tensors.append(t)
 
-    torch_dtype = _dtypes_impl.result_type_impl(dtypes)
+    torch_dtype = _dtypes_impl.result_type_impl(*tensors)
     return _dtypes.dtype(torch_dtype)

--- a/torch_np/_reductions.py
+++ b/torch_np/_reductions.py
@@ -342,7 +342,7 @@ def average(
             weights = weights.swapaxes(-1, axis)
 
         # do the work
-        result_dtype = _dtypes_impl.result_type_impl([a.dtype, weights.dtype])
+        result_dtype = _dtypes_impl.result_type_impl(a, weights)
         numerator = sum(a * weights, axis, dtype=result_dtype)
         wsum = sum(weights, axis, dtype=result_dtype)
         result = numerator / wsum

--- a/torch_np/linalg.py
+++ b/torch_np/linalg.py
@@ -21,7 +21,7 @@ def _atleast_float_1(a):
 
 
 def _atleast_float_2(a, b):
-    dtyp = _dtypes_impl.result_type_impl((a.dtype, b.dtype))
+    dtyp = _dtypes_impl.result_type_impl(a, b)
     if not (dtyp.is_floating_point or dtyp.is_complex):
         dtyp = _dtypes_impl.default_dtypes.float_dtype
 


### PR DESCRIPTION
Make result_type inference use tensors internally. This simplifies internal usage a bit, and serves as a prerequisite for introducing weak scalars, cf gh-137 (off which this PR is split).