### PR TITLE
ENH: NEP 50 "weak scalars" with dtype and PyTorch defaults

### DIFF
--- a/torch_np/_dtypes_impl.py
+++ b/torch_np/_dtypes_impl.py
@@ -53,7 +53,7 @@ def result_type_impl(*tensors):
 
 # ### NEP 50 helpers ###
 
-SCALAR_TYPES = (int, bool, float, complex)
+SCALAR_TYPES = {int, bool, float, complex}
 
 
 def _dtype_for_scalar(py_type):

--- a/torch_np/tests/test_nep50_examples.py
+++ b/torch_np/tests/test_nep50_examples.py
@@ -102,8 +102,8 @@ def test_nep50_exceptions(example):
 
 # ### Directly compare to numpy ###
 
-weaks = [True, 1, 2.0, 3j]
-non_weaks = [
+weaks = (True, 1, 2.0, 3j)
+non_weaks = (
     tnp.asarray(True),
     tnp.uint8(1),
     tnp.int8(1),
@@ -113,19 +113,42 @@ non_weaks = [
     tnp.float64(1),
     tnp.complex64(1),
     tnp.complex128(1),
-]
+)
+if HAVE_NUMPY:
+    dtypes = (
+        None,
+        _np.bool_,
+        _np.uint8,
+        _np.int8,
+        _np.int32,
+        _np.int64,
+        _np.float32,
+        _np.float64,
+        _np.complex64,
+        _np.complex128,
+    )
+else:
+    dtypes = (None,)
 
 
 @pytest.mark.skipif(not HAVE_NUMPY, reason="NumPy not found")
-@pytest.mark.parametrize("scalar, array", itertools.product(weaks, non_weaks))
-def test_direct_compare(scalar, array):
+@pytest.mark.parametrize(
+    "scalar, array, dtype", itertools.product(weaks, non_weaks, dtypes)
+)
+def test_direct_compare(scalar, array, dtype):
     # compare to NumPy w/ NEP 50.
     try:
         state = _np._get_promotion_state()
         _np._set_promotion_state("weak")
 
-        result = (scalar + array).tensor.numpy()
-        result_numpy = scalar + array.tensor.numpy()
+        try:
+            result_numpy = _np.add(scalar, array.tensor.numpy(), dtype=_np.dtype(dtype))
+        except Exception:
+            return
+        kwargs = {}
+        if dtype is not None:
+            kwargs = {"dtype": getattr(tnp, dtype.__name__)}
+        result = tnp.add(scalar, array, **kwargs).tensor.numpy()
         assert result.dtype == result_numpy.dtype
         assert result == result_numpy
 

--- a/torch_np/tests/test_nep50_examples.py
+++ b/torch_np/tests/test_nep50_examples.py
@@ -141,10 +141,13 @@ def test_direct_compare(scalar, array, dtype):
         state = _np._get_promotion_state()
         _np._set_promotion_state("weak")
 
+        if dtype is not None:
+            kwargs = {"dtype": dtype}
         try:
-            result_numpy = _np.add(scalar, array.tensor.numpy(), dtype=_np.dtype(dtype))
+            result_numpy = _np.add(scalar, array.tensor.numpy(), **kwargs)
         except Exception:
             return
+
         kwargs = {}
         if dtype is not None:
             kwargs = {"dtype": getattr(tnp, dtype.__name__)}

--- a/torch_np/tests/test_ufuncs_basic.py
+++ b/torch_np/tests/test_ufuncs_basic.py
@@ -380,10 +380,6 @@ class TestUfuncDtypeKwd:
         assert r32.dtype == "float32"
         assert r32 == 1
 
-        # casting of floating inputs to booleans
-        with assert_raises(TypeError):
-            np.add(1.0, 1e-15, dtype=bool)
-
         # now force the cast
         rb = np.add(1.0, 1e-15, dtype=bool, casting="unsafe")
         assert rb.dtype == bool


### PR DESCRIPTION
Note that this PR is against the branch from https://github.com/Quansight-Labs/numpy_pytorch_interop/pull/140.

This PR tries to solve in a clean way some simpler cases first (dtype is not None, or we have two tensors) to be able to deal with the tricky part having some preconditions on the data. This fixes a couple bugs that were latent in the other branch. It also adds a test to test for this case.

The logic to solve NEP 50 is still that of https://github.com/Quansight-Labs/numpy_pytorch_interop/pull/140 for the tricky case.

It also tries to avoid iterations over lists that can be very slow. See if the timings of CI agree with this.