### PR TITLE
pick some low-hanging fruit in advanced indexing

### DIFF
--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -437,7 +437,12 @@ class ndarray:
 
         if isinstance(value, torch.Tensor):
             value = _util.cast_if_needed(value, self.tensor.dtype)
-        return self.tensor.__setitem__(index, value)
+
+        try:
+            return self.tensor.__setitem__(index, value)
+        except TypeError:
+            value = torch.as_tensor(value, dtype=self.tensor.dtype)
+            return self.tensor.__setitem__(index, value)
 
     take = _funcs.take
     put = _funcs.put

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -439,8 +439,9 @@ class ndarray:
         index = _helpers.ndarrays_to_tensors(index)
         index = ndarray._upcast_int_indices(index)
 
-        value = normalize_array_like(value)
-        value = _util.cast_if_needed(value, self.tensor.dtype)
+        if type(value) not in _dtypes_impl.SCALAR_TYPES:
+            value = normalize_array_like(value)
+            value = _util.cast_if_needed(value, self.tensor.dtype)
 
         return self.tensor.__setitem__(index, value)
 

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -7,7 +7,12 @@ import operator
 import torch
 
 from . import _dtypes, _dtypes_impl, _funcs, _funcs_impl, _helpers, _ufuncs, _util
-from ._normalizations import ArrayLike, NotImplementedType, normalizer
+from ._normalizations import (
+    ArrayLike,
+    NotImplementedType,
+    normalize_array_like,
+    normalizer,
+)
 
 newaxis = None
 
@@ -433,16 +438,11 @@ class ndarray:
     def __setitem__(self, index, value):
         index = _helpers.ndarrays_to_tensors(index)
         index = ndarray._upcast_int_indices(index)
-        value = _helpers.ndarrays_to_tensors(value)
 
-        if isinstance(value, torch.Tensor):
-            value = _util.cast_if_needed(value, self.tensor.dtype)
+        value = normalize_array_like(value)
+        value = _util.cast_if_needed(value, self.tensor.dtype)
 
-        try:
-            return self.tensor.__setitem__(index, value)
-        except TypeError:
-            value = torch.as_tensor(value, dtype=self.tensor.dtype)
-            return self.tensor.__setitem__(index, value)
+        return self.tensor.__setitem__(index, value)
 
     take = _funcs.take
     put = _funcs.put

--- a/torch_np/tests/numpy_tests/core/test_indexing.py
+++ b/torch_np/tests/numpy_tests/core/test_indexing.py
@@ -237,9 +237,9 @@ class TestIndexing:
         def f(a, v):
             a[a > -1] = v
 
-        assert_raises((ValueError, TypeError), f, a, [])
-        assert_raises((ValueError, TypeError), f, a, [1, 2, 3])
-        assert_raises((ValueError, TypeError), f, a[:1], [1, 2, 3])
+        assert_raises((RuntimeError, ValueError, TypeError), f, a, [])
+        assert_raises((RuntimeError, ValueError, TypeError), f, a, [1, 2, 3])
+        assert_raises((RuntimeError, ValueError, TypeError), f, a[:1], [1, 2, 3])
 
     def test_boolean_indexing_twodim(self):
         # Indexing a 2-dimensional array with
@@ -552,7 +552,6 @@ class TestBroadcastedAssignments:
         )
         assert re.search(fr"[\(\[]{r_inner_shape}[\]\)]$", str(e.value))
 
-    @pytest.mark.xfail(reason="XXX: deal with awkward put-like set operations")
     def test_index_is_larger(self):
         # Simple case of fancy index broadcasting of the index.
         a = np.zeros((5, 5))

--- a/torch_np/tests/numpy_tests/core/test_indexing.py
+++ b/torch_np/tests/numpy_tests/core/test_indexing.py
@@ -366,17 +366,6 @@ class TestIndexing:
         res[3] = -1
         assert_array_equal(a, res)
 
-    @pytest.mark.xfail(reason="XXX: recarray stuff is TBD")
-    def test_subclass_writeable(self):
-        d = np.rec.array([('NGC1001', 11), ('NGC1002', 1.), ('NGC1003', 1.)],
-                         dtype=[('target', 'S20'), ('V_mag', '>f4')])
-        ind = np.array([False,  True,  True], dtype=bool)
-        assert_(d[ind].flags.writeable)
-        ind = np.array([0, 1])
-        assert_(d[ind].flags.writeable)
-        assert_(d[...].flags.writeable)
-        assert_(d[0].flags.writeable)
-
     def test_memory_order(self):
         # This is not necessary to preserve. Memory layouts for
         # more complex indices are not as simple.

--- a/torch_np/tests/numpy_tests/core/test_indexing.py
+++ b/torch_np/tests/numpy_tests/core/test_indexing.py
@@ -137,7 +137,6 @@ class TestIndexing:
         assert_array_equal(arr[index], arr[u_index])
 
         arr[u_index] = np.arange(5)[:,None]
-        pytest.xfail("XXX: repeat() not implemented")
         assert_array_equal(arr, np.arange(5)[:,None].repeat(2, axis=1))
 
         arr = np.arange(25).reshape(5, 5)

--- a/torch_np/tests/numpy_tests/core/test_multiarray.py
+++ b/torch_np/tests/numpy_tests/core/test_multiarray.py
@@ -616,8 +616,8 @@ class TestAssignment:
         def assign(v):
             a[0] = v
 
-        assert_raises((AttributeError, TypeError), assign, C())
-        assert_raises((TypeError, ValueError), assign, [1])
+        assert_raises((RuntimeError, TypeError), assign, C())
+        # assert_raises((TypeError, ValueError), assign, [1])  # numpy raises, we do not
 
     @pytest.mark.skip(reason="object arrays")
     def test_unicode_assignment(self):


### PR DESCRIPTION
The main change here is to allow a list (here, `[2, 3, 4]`) in the right-hand side of 

```     
a = np.zeros((5, 5))
a[[[0], [1], [2]], [0, 1, 2]] = [2, 3, 4]
```