### PR TITLE
ENH: add np.append

### DIFF
--- a/autogen/numpy_api_dump.py
+++ b/autogen/numpy_api_dump.py
@@ -62,10 +62,6 @@ def seterrobj(errobj):
     raise NotImplementedError
 
 
-def append(arr, values, axis=None):
-    raise NotImplementedError
-
-
 def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     raise NotImplementedError
 

--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -188,6 +188,15 @@ def stack(
     return torch.stack(tensors, axis=axis)
 
 
+def append(arr: ArrayLike, values: ArrayLike, axis=None):
+    if axis is None:
+        if arr.ndim != 1:
+            arr = arr.flatten()
+        values = values.flatten()
+        axis = arr.ndim - 1
+    return _concatenate((arr, values), axis=axis)
+
+
 # ### split ###
 
 

--- a/torch_np/tests/test_function_base.py
+++ b/torch_np/tests/test_function_base.py
@@ -75,3 +75,17 @@ class TestArange:
         with pytest.raises((ValueError, RuntimeError)):
             # Fails discovering start dtype
             np.arange(*args)
+
+
+class TestAppend:
+    # tests taken from np.append docstring
+    def test_basic(self):
+        result = np.append([1, 2, 3], [[4, 5, 6], [7, 8, 9]])
+        assert_equal(result, np.arange(1, 10, dtype=int))
+
+        # When `axis` is specified, `values` must have the correct shape.
+        result = np.append([[1, 2, 3], [4, 5, 6]], [[7, 8, 9]], axis=0)
+        assert_equal(result, np.arange(1, 10, dtype=int).reshape((3, 3)))
+
+        with pytest.raises((RuntimeError, ValueError)):
+            np.append([[1, 2, 3], [4, 5, 6]], [7, 8, 9], axis=0)


### PR DESCRIPTION
Vendor the numpy source; take docstring examples into tests.