### PR TITLE
MAINT: Add `ndarray.__contains__`, remove ndarray attributes which should not be there

### DIFF
--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -202,6 +202,9 @@ class ndarray:
         lambda self, other: _ufuncs.divmod(other, self), "__rdivmod__"
     )
 
+    # prevent loop variables leaking into the ndarray class namespace
+    del ivar, rvar, name, plain, fn, method
+
     @property
     def shape(self):
         return tuple(self.tensor.shape)

--- a/torch_np/_ndarray.py
+++ b/torch_np/_ndarray.py
@@ -396,6 +396,9 @@ class ndarray:
     def __len__(self):
         return self.tensor.shape[0]
 
+    def __contains__(self, x):
+        return self.tensor.__contains__(x)
+
     ### methods to match namespace functions
     def transpose(self, *axes):
         # np.transpose(arr, axis=None) but arr.transpose(*axes)

--- a/torch_np/tests/test_ndarray_methods.py
+++ b/torch_np/tests/test_ndarray_methods.py
@@ -567,3 +567,18 @@ class TestAmin:
 
         arr = np.asarray(a)
         assert_equal(np.amin(arr), arr.min())
+
+
+def test_contains():
+    a = np.arange(12).reshape(3, 4)
+    assert 2 in a
+    assert not 42 in a
+
+
+# make sure ndarray does not carry extra methods/attributes
+# >>> set(dir(a)) - set(dir(a.tensor.numpy()))
+@pytest.mark.parametrize("name", ["fn", "ivar", "method", "name", "plain", "rvar"])
+def test_extra_methods(name):
+    a = np.ones(3)
+    with pytest.raises(AttributeError):
+        getattr(a, name)


### PR DESCRIPTION
- Add support for  testing using builtin `in`:   `1 in np.arange(3)` etc
- remove severall ndarray attributes which inadvertently leaked into the class namespace 
- make `ndarray._upcast_int_indices` a module level function instead of a staticmethod