### PR TITLE
fix dtype edge cases in var, std, dot; remove (some) expired xfails

### DIFF
--- a/torch_np/_funcs_impl.py
+++ b/torch_np/_funcs_impl.py
@@ -1243,6 +1243,10 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes=2):
 
 def dot(a: ArrayLike, b: ArrayLike, out: Optional[OutArray] = None):
     dtype = _dtypes_impl.result_type_impl(a, b)
+    is_bool = dtype == torch.bool
+    if is_bool:
+        dtype = torch.uint8
+
     a = _util.cast_if_needed(a, dtype)
     b = _util.cast_if_needed(b, dtype)
 
@@ -1250,6 +1254,10 @@ def dot(a: ArrayLike, b: ArrayLike, out: Optional[OutArray] = None):
         result = a * b
     else:
         result = torch.matmul(a, b)
+
+    if is_bool:
+        result = result.to(torch.bool)
+
     return result
 
 

--- a/torch_np/_reductions.py
+++ b/torch_np/_reductions.py
@@ -244,9 +244,11 @@ def std(
     *,
     where: NotImplementedType = None,
 ):
+    in_dtype = dtype
     dtype = _atleast_float(dtype, a.dtype)
     tensor = _util.cast_if_needed(a, dtype)
-    return tensor.std(dim=axis, correction=ddof)
+    result = tensor.std(dim=axis, correction=ddof)
+    return _util.cast_if_needed(result, in_dtype)
 
 
 @_deco_axis_expand
@@ -260,9 +262,11 @@ def var(
     *,
     where: NotImplementedType = None,
 ):
+    in_dtype = dtype
     dtype = _atleast_float(dtype, a.dtype)
     tensor = _util.cast_if_needed(a, dtype)
-    return tensor.var(dim=axis, correction=ddof)
+    result = tensor.var(dim=axis, correction=ddof)
+    return _util.cast_if_needed(result, in_dtype)
 
 
 # cumsum / cumprod are almost reductions:

--- a/torch_np/tests/numpy_tests/core/test_multiarray.py
+++ b/torch_np/tests/numpy_tests/core/test_multiarray.py
@@ -4698,7 +4698,6 @@ class TestStats:
                 res = f(mat, axis=None).dtype.type
                 assert_(res is tgt)
 
-    @pytest.mark.xfail(reason='TODO: dtype in reductions')
     def test_dtype_from_dtype(self):
         mat = np.eye(3)
 

--- a/torch_np/tests/numpy_tests/core/test_multiarray.py
+++ b/torch_np/tests/numpy_tests/core/test_multiarray.py
@@ -5666,7 +5666,6 @@ class TestMatmul(MatmulCommon):
         with assert_raises(TypeError):
             b = np.matmul(a, a)
 
-    @pytest.mark.xfail(reason="TODO: implement .view")
     def test_matmul_bool(self):
         # gh-14439
         a = np.array([[1, 0],[1, 1]], dtype=bool)
@@ -5675,9 +5674,12 @@ class TestMatmul(MatmulCommon):
         # matmul with boolean output should always be 0, 1
         assert np.max(b.view(np.uint8)) == 1
 
-        rg = np.random.default_rng(np.random.PCG64(43))
-        d = rg.integers(2, size=4*5, dtype=np.int8)
-        d = d.reshape(4, 5) > 0
+        # rg = np.random.default_rng(np.random.PCG64(43))
+        # d = rg.integers(2, size=4*5, dtype=np.int8)
+        # d = d.reshape(4, 5) > 0
+        np.random.seed(1234)
+        d = np.random.randint(2, size=(4, 5)) > 0
+
         out1 = np.matmul(d, d.reshape(5, 4))
         out2 = np.dot(d, d.reshape(5, 4))
         assert_equal(out1, out2)

--- a/torch_np/tests/numpy_tests/lib/test_function_base.py
+++ b/torch_np/tests/numpy_tests/lib/test_function_base.py
@@ -2132,7 +2132,6 @@ class Test_I0:
             res = i0(a)
 
 
-@pytest.mark.xfail(reason='TODO: implement')
 class TestKaiser:
 
     def test_simple(self):

--- a/torch_np/tests/numpy_tests/lib/test_twodim_base.py
+++ b/torch_np/tests/numpy_tests/lib/test_twodim_base.py
@@ -366,7 +366,7 @@ def test_mask_indices():
     assert_array_equal(a[iu1], array([1, 2, 5]))
 
 
-@pytest.mark.xfail(reason="TODO: fancy indexing")
+@pytest.mark.xfail(reason="np.tril_indices == our tuple(tril_indices)")
 def test_tril_indices():
     # indices without and with offset
     il1 = tril_indices(4)
@@ -414,7 +414,7 @@ def test_tril_indices():
                               [-10, -10, -10, -10, -10]]))
 
 
-@pytest.mark.xfail(reason="TODO: fancy indexing")
+@pytest.mark.xfail(reason="np.triu_indices == our tuple(triu_indices)")
 class TestTriuIndices:
     def test_triu_indices(self):
         iu1 = triu_indices(4)

--- a/torch_np/tests/numpy_tests/lib/test_type_check.py
+++ b/torch_np/tests/numpy_tests/lib/test_type_check.py
@@ -93,7 +93,6 @@ class TestIsscalar:
         assert_(np.isscalar(4.0))
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestReal:
 
     def test_real(self):
@@ -108,7 +107,7 @@ class TestReal:
         y = 1
         out = np.real(y)
         assert_equal(y, out)
-        assert_(not isinstance(out, np.ndarray))
+        # assert_(not isinstance(out, np.ndarray))  # XXX: 0D tensor, not scalar
 
     def test_cmplx(self):
         y = np.random.rand(10,)+1j*np.random.rand(10,)
@@ -122,10 +121,9 @@ class TestReal:
         y = 1 + 1j
         out = np.real(y)
         assert_equal(1.0, out)
-        assert_(not isinstance(out, np.ndarray))
+        # assert_(not isinstance(out, np.ndarray))  # XXX: 0D tensor, not scalar
 
 
-@pytest.mark.xfail(reason="not implemented")
 class TestImag:
 
     def test_real(self):
@@ -140,7 +138,7 @@ class TestImag:
         y = 1
         out = np.imag(y)
         assert_equal(0, out)
-        assert_(not isinstance(out, np.ndarray))
+        # assert_(not isinstance(out, np.ndarray))  # XXX: 0D tensor, not scalar
 
     def test_cmplx(self):
         y = np.random.rand(10,)+1j*np.random.rand(10,)
@@ -154,7 +152,7 @@ class TestImag:
         y = 1 + 1j
         out = np.imag(y)
         assert_equal(1.0, out)
-        assert_(not isinstance(out, np.ndarray))
+        # assert_(not isinstance(out, np.ndarray))  # XXX: 0D tensor, not scalar
 
 
 class TestIscomplex:

--- a/torch_np/tests/test_nep50_examples.py
+++ b/torch_np/tests/test_nep50_examples.py
@@ -19,6 +19,7 @@ from torch_np import (
     float64,
     inf,
     int16,
+    int32,
     int64,
     uint8,
 )
@@ -57,13 +58,14 @@ examples = {
     "uint8(1) + 300": (int64(301), Exception),
     "uint8(100) + 200": (int64(301), uint8(44)),  # and RuntimeWarning
     "float32(1) + 3e100": (float64(3e100), float32(inf)),  # and RuntimeWarning [T7]
-    "array([0.1], float32) == 0.1": (
-        array([False]),
-        unchanged,
-    ),  # XXX: a typo in NEP50?
+    "array([1.0], float32) + 1e-14 == 1.0": (array([True]), unchanged),
     "array([0.1], float32) == float64(0.1)": (array([True]), array([False])),
+    "array(1.0, float32) + 1e-14 == 1.0": (array(False), array(True)),
     "array([1.], float32) + 3": (array([4.0], float32), unchanged),
     "array([1.], float32) + int64(3)": (array([4.0], float32), array([4.0], float64)),
+    "3j + array(3, complex64)": (array(3 + 3j, complex128), array(3 + 3j, complex64)),
+    "float32(1) + 1j": (array(1 + 1j, complex128), array(1 + 1j, complex64)),
+    "int32(1) + 5j": (array(1 + 5j, complex128), unchanged),
     # additional examples from the NEP text
     "int16(2) + 2": (int64(4), int16(4)),
     "int16(4) + 4j": (complex128(4 + 4j), unchanged),
@@ -73,16 +75,8 @@ examples = {
 }
 
 
-fails = [
-    "array([0.1], float32) == 0.1",  # TODO: fix the example
-]
-
-
 @pytest.mark.parametrize("example", examples)
 def test_nep50_exceptions(example):
-
-    if example in fails:
-        pytest.xfail(reason="scalars")
 
     old, new = examples[example]
 

--- a/torch_np/tests/test_ufuncs_basic.py
+++ b/torch_np/tests/test_ufuncs_basic.py
@@ -257,14 +257,12 @@ class TestNdarrayDunderVsUfunc:
         assert_equal(result, ufunc(a, b))
 
         if result.dtype != np.result_type(a, b):
-            pytest.xfail(reason="prob need weak type promotion (scalars)")
             assert result.dtype == np.result_type(a, b)
 
         # __rop__
         result = op(b, a)
         assert_equal(result, ufunc(b, a))
         if result.dtype != np.result_type(a, b):
-            pytest.xfail(reason="prob need weak type promotion (scalars)")
             assert result.dtype == np.result_type(a, b)
 
         # __iop__ : casts the result to self.dtype, raises if cannot
@@ -276,7 +274,6 @@ class TestNdarrayDunderVsUfunc:
             result = iop(a, b)
             assert_equal(result, ufunc(a0, b))
             if result.dtype != np.result_type(a, b):
-                pytest.xfail(reason="prob need weak type promotion (scalars)")
                 assert result.dtype == np.result_type(a0, b)
 
         else:
@@ -297,14 +294,12 @@ class TestNdarrayDunderVsUfunc:
         result = op(a, b)
         assert_equal(result, ufunc(a, b))
         if result.dtype != np.result_type(a, b):
-            pytest.xfail(reason="prob need weak type promotion (scalars)")
             assert result.dtype == np.result_type(a, b)
 
         # __rop__(other array)
         result = op(b, a)
         assert_equal(result, ufunc(b, a))
         if result.dtype != np.result_type(a, b):
-            pytest.xfail(reason="prob need weak type promotion (scalars)")
             assert result.dtype == np.result_type(a, b)
 
         # __iop__
@@ -316,7 +311,6 @@ class TestNdarrayDunderVsUfunc:
             result = iop(a, b)
             assert_equal(result, ufunc(a0, b))
             if result.dtype != np.result_type(a, b):
-                pytest.xfail(reason="prob need weak type promotion (scalars)")
                 assert result.dtype == np.result_type(a0, b)
         else:
             with assert_raises((TypeError, RuntimeError)):  # XXX np.UFuncTypeError
@@ -333,7 +327,6 @@ class TestNdarrayDunderVsUfunc:
         assert_equal(result_op, result_ufunc)
 
         if result_op.dtype != result_ufunc.dtype:
-            pytest.xfail(reason="prob need weak type promotion (scalars)")
             assert result_op.dtype == result_ufunc.dtype
 
         # __rop__
@@ -344,7 +337,6 @@ class TestNdarrayDunderVsUfunc:
         assert_equal(result_op, result_ufunc)
 
         if result_op.dtype != result_ufunc.dtype:
-            pytest.xfail(reason="prob need weak type promotion (scalars)")
             assert result_op.dtype == result_ufunc.dtype
 
         # __iop__ : in-place ops (`self += other` etc) do not broadcast self
@@ -363,7 +355,6 @@ class TestNdarrayDunderVsUfunc:
         assert_equal(result, result_ufunc)
 
         if result_op.dtype != result_ufunc.dtype:
-            pytest.xfail(reason="prob need weak type promotion (scalars)")
             assert result_op.dtype == result_ufunc.dtype
 
 


### PR DESCRIPTION
- Comb through xfails, remove several unneeded ones or fix small errors which these xfails were masking.
- Update the NEP50 test for the NEP update.