### PR TITLE
MAINT: remove abc.ABC from dtype hierarchy

### DIFF
--- a/torch_np/_dtypes.py
+++ b/torch_np/_dtypes.py
@@ -1,7 +1,6 @@
 """ Define analogs of numpy dtypes supported by pytorch.
 Define the scalar types and supported dtypes and numpy <--> torch dtype mappings.
 """
-import abc
 import builtins
 
 import torch
@@ -15,9 +14,8 @@ __all__ = ["dtype", "DType", "typecodes", "issubdtype", "set_default_dtype"]
 # ### Scalar types ###
 
 
-class generic(abc.ABC):
+class generic:
     @property
-    @abc.abstractmethod
     def name(self):
         return self.__class__.__name__
 


### PR DESCRIPTION
as discussed over at https://github.com/pytorch/pytorch/pull/103546

With this, both dtype and array scalars are regular classes/objects:

```
In [6]: tnp.float32.__mro__
Out[6]: 
(torch_np._dtypes.float32,
 torch_np._dtypes.floating,
 torch_np._dtypes.inexact,
 torch_np._dtypes.number,
 torch_np._dtypes.generic,
 object)

In [7]: tnp.dtype(int).__class__.__mro__
Out[7]: (torch_np._dtypes.DType, object)
```

cc @lezcano @larryliu0820 