### PR TITLE
[DO NOT MERGE]: torch.compile test functions

### DIFF
--- a/torch_np/tests/conftest.py
+++ b/torch_np/tests/conftest.py
@@ -75,3 +75,11 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
+
+
+import torch
+
+def pytest_runtest_call(item):
+    compiled = torch.compile(item.function)
+    item.runtest()
+    compiled(item, **item.funcargs)     # the 1st argument is a placeholder


### PR DESCRIPTION
Hack in a torch.compile into test functions. 
This is _very_ slow, and the output is _very_ long. One strategy could be to run it on a test file/class, and then rerun the failing tests one by one.